### PR TITLE
fix: mount uploads volume to LibreChat container for image persistence

### DIFF
--- a/az_container_app_definitions/n1_container_app_definition.yml
+++ b/az_container_app_definitions/n1_container_app_definition.yml
@@ -171,10 +171,8 @@ properties:
         volumeMounts:
           - volumeName: fspaichateastusn1001
             mountPath: /app/uploads
-            subPath: uploads
           - volumeName: fspaichateastusn1001
             mountPath: /app/client/public/images
-            subPath: images
       - image: conpaychexaiprod001.azurecr.io/paychex/rag_api:n1.latest
         name: conpairag
         env:
@@ -216,7 +214,6 @@ properties:
         volumeMounts:
           - volumeName: fspaichateastusn1001
             mountPath: /app/uploads
-            subPath: uploads
     initContainers: null
     scale:
       minReplicas: 3

--- a/az_container_app_definitions/n1_container_app_definition.yml
+++ b/az_container_app_definitions/n1_container_app_definition.yml
@@ -168,6 +168,11 @@ properties:
           memory: 2Gi
           ephemeralStorage: 4Gi
         probes: []
+        volumeMounts:
+          - volumeName: fspaichateastusn1001
+            mountPath: /app/uploads
+          - volumeName: fspaichateastusn1001
+            mountPath: /app/client/public/images
       - image: conpaychexaiprod001.azurecr.io/paychex/rag_api:n1.latest
         name: conpairag
         env:

--- a/az_container_app_definitions/n1_container_app_definition.yml
+++ b/az_container_app_definitions/n1_container_app_definition.yml
@@ -171,8 +171,10 @@ properties:
         volumeMounts:
           - volumeName: fspaichateastusn1001
             mountPath: /app/uploads
+            subPath: uploads
           - volumeName: fspaichateastusn1001
             mountPath: /app/client/public/images
+            subPath: images
       - image: conpaychexaiprod001.azurecr.io/paychex/rag_api:n1.latest
         name: conpairag
         env:
@@ -214,6 +216,7 @@ properties:
         volumeMounts:
           - volumeName: fspaichateastusn1001
             mountPath: /app/uploads
+            subPath: uploads
     initContainers: null
     scale:
       minReplicas: 3

--- a/az_container_app_definitions/n2a_container_app_definition.yml
+++ b/az_container_app_definitions/n2a_container_app_definition.yml
@@ -167,8 +167,10 @@ properties:
         volumeMounts:
           - volumeName: fspaichateastusn2a001
             mountPath: /app/uploads
+            subPath: uploads
           - volumeName: fspaichateastusn2a001
             mountPath: /app/client/public/images
+            subPath: images
       - image: conpaychexaiprod001.azurecr.io/paychex/rag_api:n2a.latest
         name: conpairag
         env:
@@ -210,6 +212,7 @@ properties:
         volumeMounts:
           - volumeName: fspaichateastusn2a001
             mountPath: /app/uploads
+            subPath: uploads
     initContainers: null
     scale:
       minReplicas: 3

--- a/az_container_app_definitions/n2a_container_app_definition.yml
+++ b/az_container_app_definitions/n2a_container_app_definition.yml
@@ -167,10 +167,8 @@ properties:
         volumeMounts:
           - volumeName: fspaichateastusn2a001
             mountPath: /app/uploads
-            subPath: uploads
           - volumeName: fspaichateastusn2a001
             mountPath: /app/client/public/images
-            subPath: images
       - image: conpaychexaiprod001.azurecr.io/paychex/rag_api:n2a.latest
         name: conpairag
         env:
@@ -212,7 +210,6 @@ properties:
         volumeMounts:
           - volumeName: fspaichateastusn2a001
             mountPath: /app/uploads
-            subPath: uploads
     initContainers: null
     scale:
       minReplicas: 3

--- a/az_container_app_definitions/n2a_container_app_definition.yml
+++ b/az_container_app_definitions/n2a_container_app_definition.yml
@@ -164,6 +164,11 @@ properties:
           memory: 4Gi
           ephemeralStorage: 4Gi
         probes: []
+        volumeMounts:
+          - volumeName: fspaichateastusn2a001
+            mountPath: /app/uploads
+          - volumeName: fspaichateastusn2a001
+            mountPath: /app/client/public/images
       - image: conpaychexaiprod001.azurecr.io/paychex/rag_api:n2a.latest
         name: conpairag
         env:

--- a/az_container_app_definitions/prod_container_app_definition.yml
+++ b/az_container_app_definitions/prod_container_app_definition.yml
@@ -130,8 +130,10 @@ properties:
       volumeMounts:
         - volumeName: fspaichateastusprod001
           mountPath: /app/uploads
+          subPath: uploads
         - volumeName: fspaichateastusprod001
           mountPath: /app/client/public/images
+          subPath: images
     - image: conpaychexaiprod001.azurecr.io/paychex/rag_api:prod.latest
       name: conpairag
       env:
@@ -173,6 +175,7 @@ properties:
       volumeMounts:
         - volumeName: fspaichateastusprod001
           mountPath: /app/uploads
+          subPath: uploads
     scale:
       minReplicas: 3
       maxReplicas: 6

--- a/az_container_app_definitions/prod_container_app_definition.yml
+++ b/az_container_app_definitions/prod_container_app_definition.yml
@@ -127,6 +127,11 @@ properties:
         cpu: 1
         memory: 8Gi
         ephemeralStorage: 4Gi
+      volumeMounts:
+        - volumeName: fspaichateastusprod001
+          mountPath: /app/uploads
+        - volumeName: fspaichateastusprod001
+          mountPath: /app/client/public/images
     - image: conpaychexaiprod001.azurecr.io/paychex/rag_api:prod.latest
       name: conpairag
       env:

--- a/az_container_app_definitions/prod_container_app_definition.yml
+++ b/az_container_app_definitions/prod_container_app_definition.yml
@@ -130,10 +130,8 @@ properties:
       volumeMounts:
         - volumeName: fspaichateastusprod001
           mountPath: /app/uploads
-          subPath: uploads
         - volumeName: fspaichateastusprod001
           mountPath: /app/client/public/images
-          subPath: images
     - image: conpaychexaiprod001.azurecr.io/paychex/rag_api:prod.latest
       name: conpairag
       env:
@@ -175,7 +173,6 @@ properties:
       volumeMounts:
         - volumeName: fspaichateastusprod001
           mountPath: /app/uploads
-          subPath: uploads
     scale:
       minReplicas: 3
       maxReplicas: 6


### PR DESCRIPTION
- Add volumeMounts to conpaichat container in N1, N2A, and PROD
- Mount existing Azure File share to both /app/uploads and /app/client/public/images
- Fixes clipboard-pasted images not being retained after container restart
- No new infrastructure required - reuses existing Azure File shares