### PR TITLE
feat(ui): group models by endpoint with descriptions for v0.8.1

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
@@ -2,12 +2,7 @@ import React, { useMemo } from 'react';
 import type { ModelSelectorProps } from '~/common';
 import { ModelSelectorProvider, useModelSelectorContext } from './ModelSelectorContext';
 import { ModelSelectorChatProvider } from './ModelSelectorChatContext';
-import {
-  renderModelSpecs,
-  renderEndpoints,
-  renderSearchResults,
-  renderCustomGroups,
-} from './components';
+import { renderEndpoints, renderSearchResults } from './components';
 import { getSelectedIcon, getDisplayValue } from './utils';
 import { CustomMenu as Menu } from './CustomMenu';
 import DialogManager from './DialogManager';
@@ -87,21 +82,9 @@ function ModelSelectorContent() {
         combobox={<input placeholder={localize('com_endpoint_search_models')} />}
         trigger={trigger}
       >
-        {searchResults ? (
-          renderSearchResults(searchResults, localize, searchValue)
-        ) : (
-          <>
-            {/* Render ungrouped modelSpecs (no group field) */}
-            {renderModelSpecs(
-              modelSpecs?.filter((spec) => !spec.group) || [],
-              selectedValues.modelSpec || '',
-            )}
-            {/* Render endpoints (will include grouped specs matching endpoint names) */}
-            {renderEndpoints(mappedEndpoints ?? [])}
-            {/* Render custom groups (specs with group field not matching any endpoint) */}
-            {renderCustomGroups(modelSpecs || [], mappedEndpoints ?? [])}
-          </>
-        )}
+        {searchResults
+          ? renderSearchResults(searchResults, localize, searchValue)
+          : renderEndpoints(mappedEndpoints ?? [])}
       </Menu>
       <DialogManager
         keyDialogOpen={keyDialogOpen}

--- a/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
@@ -61,13 +61,3 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
     </MenuItem>
   );
 }
-
-export function renderModelSpecs(specs: TModelSpec[], selectedSpec: string) {
-  if (!specs || specs.length === 0) {
-    return null;
-  }
-
-  return specs.map((spec) => (
-    <ModelSpecItem key={spec.name} spec={spec} isSelected={selectedSpec === spec.name} />
-  ));
-}

--- a/client/src/components/Chat/Menus/Endpoints/components/index.ts
+++ b/client/src/components/Chat/Menus/Endpoints/components/index.ts
@@ -2,4 +2,3 @@ export * from './ModelSpecItem';
 export * from './EndpointModelItem';
 export * from './EndpointItem';
 export * from './SearchResults';
-export * from './CustomGroup';


### PR DESCRIPTION
This commit reimplements model grouping functionality for v0.8.1, providing a cleaner and more organized model selector experience.

## Changes

### ModelSelectorContext.tsx
- Added 'modelSpecsByEndpoint' computed property that groups model specs by their preset endpoint for efficient O(1) lookup
- Removed unused 'conversation' dependency from useSelectMention hook
- Exported 'modelSpecsByEndpoint' in the context value

### EndpointItem.tsx
- Replaced per-render useMemo filtering with pre-computed modelSpecsByEndpoint
- Added new 'hasSpecModels' rendering path that:
  - Shows model specs grouped under their endpoint provider
  - Supports searching/filtering by spec label and description
  - Displays spec descriptions for better discoverability
  - Falls back to 'No results' message when search yields nothing
- Standardized CSS classes (flex-shrink -> shrink for Tailwind v3)
- Moved search placeholder computation to component level

### ModelSelector.tsx
- Simplified rendering logic to only use renderEndpoints
- Removed renderModelSpecs and renderCustomGroups (now handled in EndpointItem)
- Cleaner conditional rendering with ternary

### ModelSpecItem.tsx
- Removed deprecated 'renderModelSpecs' export function
- Component now used directly by EndpointItem

### components/index.ts
- Removed CustomGroup export (no longer needed)

## Benefits
- Models are now properly grouped under their provider (e.g., all OpenAI models under OpenAI, all Anthropic models under Anthropic)
- Model descriptions are visible in the dropdown for better UX
- Search works across both model labels and descriptions
- More efficient rendering with pre-computed groupings
- Cleaner separation of concerns between components

## Compatibility
- Works with v0.8.1 upstream codebase
- Backward compatible with existing librechat.yaml configurations
- No breaking changes to model spec configuration format