### PR TITLE
fix(n2a): prevent RAG API trigger timeout by not waiting for completion

### DIFF
--- a/.github/workflows/n2a-build-and-push.yml
+++ b/.github/workflows/n2a-build-and-push.yml
@@ -78,6 +78,7 @@ jobs:
                 workflow_id: '.github/workflows/n2-build-and-push.yml'
                 github_token: ${{ secrets.CROSS_REPO_PAT }}
                 ref: 'main'
+                wait_for_completion: false
 
             - name: Update librechat image in YAML
               uses: mikefarah/yq@master


### PR DESCRIPTION
The remote-workflow-trigger action was waiting for RAG API build to complete, causing timeout errors when the build takes longer than the action's timeout.

- Add wait_for_completion: false to fire-and-forget the RAG API trigger
- RAG API build still runs, just doesn't block N2A deployment
- LibreChat deployment continues immediately after triggering

This fixes the 'Connect Timeout Error' seen in N2A deployments.