### PR TITLE
fix(api): filter orphaned tool call refs and empty messages

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -895,6 +895,8 @@ class BaseClient {
 
     _messages = await this.addPreviousAttachments(_messages);
 
+    _messages = this.filterCrossProviderToolCalls(_messages);
+
     if (!this.shouldSummarize) {
       return _messages;
     }
@@ -918,6 +920,73 @@ class BaseClient {
     }
 
     return _messages;
+  }
+
+  /**
+   * Filters out tool-related content from messages created by a different provider.
+   * This prevents errors when switching AI providers mid-conversation.
+   *
+   * @param {TMessage[]} messages - Array of messages to filter
+   * @returns {TMessage[]} Messages with tool content filtered based on endpoint
+   */
+  filterCrossProviderToolCalls(messages) {
+    const currentEndpoint = this.options?.endpoint;
+
+    if (!currentEndpoint || !messages || messages.length === 0) {
+      return messages;
+    }
+
+    return messages
+      .map((message) => {
+        if (message.endpoint === currentEndpoint || !message.endpoint) {
+          return message;
+        }
+
+        if (!Array.isArray(message.content)) {
+          return message;
+        }
+
+        // Filter out tool_call types from different endpoint
+        const filteredContent = message.content.filter((part) => {
+          if (part.type === ContentTypes.TOOL_CALL) {
+            return false;
+          }
+          // Filter text parts that announce tool calls
+          if (part.type === ContentTypes.TEXT && part.tool_call_ids?.length) {
+            return false;
+          }
+          return true;
+        });
+
+        if (filteredContent.length === 0) {
+          logger.debug(
+            '[BaseClient] Excluding message with only tool content from different provider:',
+            {
+              messageId: message.messageId,
+              fromEndpoint: message.endpoint,
+              toEndpoint: currentEndpoint,
+            },
+          );
+          return null;
+        }
+
+        if (filteredContent.length !== message.content.length) {
+          logger.debug('[BaseClient] Filtered tool calls from message:', {
+            messageId: message.messageId,
+            fromEndpoint: message.endpoint,
+            toEndpoint: currentEndpoint,
+            removedCount: message.content.length - filteredContent.length,
+          });
+
+          return {
+            ...message,
+            content: filteredContent,
+          };
+        }
+
+        return message;
+      })
+      .filter((message) => message !== null);
   }
 
   /**


### PR DESCRIPTION
When switching AI providers mid-conversation, tool call content from the previous provider can cause errors. This adds filtering to:

- Remove tool_call content types from different endpoints
- Filter text parts that reference tool_call_ids
- Exclude messages that become empty after filtering

Prevents 'tool_call_id not found' errors when switching providers.