### PR TITLE
Feature/AIA-2066 Tavily always on and AIA-1805 - Tavily Sources in search results

### DIFF
--- a/client/src/components/Chat/ChatView.tsx
+++ b/client/src/components/Chat/ChatView.tsx
@@ -7,7 +7,7 @@ import { Constants, buildTree } from 'librechat-data-provider';
 import type { TMessage } from 'librechat-data-provider';
 import type { ChatFormValues } from '~/common';
 import { ChatContext, AddedChatContext, useFileMapContext, ChatFormProvider } from '~/Providers';
-import { useChatHelpers, useAddedResponse, useSSE } from '~/hooks';
+import { useChatHelpers, useAddedResponse, useSSE, useMCPSelect } from '~/hooks';
 import ConversationStarters from './Input/ConversationStarters';
 import { useGetMessagesByConvoId } from '~/data-provider';
 import MessagesView from './Messages/MessagesView';
@@ -34,6 +34,9 @@ function ChatView({ index = 0 }: { index?: number }) {
   const rootSubmission = useRecoilValue(store.submissionByIndex(index));
   const addedSubmission = useRecoilValue(store.submissionByIndex(index + 1));
   const centerFormOnLanding = useRecoilValue(store.centerFormOnLanding);
+
+  // Initialize MCP selection for this conversation (including auto-select for new conversations)
+  useMCPSelect({ conversationId });
 
   const fileMap = useFileMapContext();
 

--- a/client/src/components/Chat/Messages/Content/TavilySources.tsx
+++ b/client/src/components/Chat/Messages/Content/TavilySources.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { ExternalLink } from 'lucide-react';
+import { useLocalize } from '~/hooks';
+
+interface TavilyResult {
+  title?: string;
+  url: string;
+  content?: string;
+  score?: number;
+  raw_content?: string;
+}
+
+interface TavilyResponse {
+  query?: string;
+  answer?: string;
+  results?: TavilyResult[];
+  images?: Array<{
+    url: string;
+    description?: string;
+  }>;
+  follow_up_questions?: string[];
+  response_time?: number;
+}
+
+interface TavilySourcesProps {
+  output: string;
+  showFallback?: (show: boolean) => void;
+}
+
+export default function TavilySources({ output, showFallback }: TavilySourcesProps) {
+  const localize = useLocalize();
+  const parsedData = React.useMemo(() => {
+    try {
+      // First, try to parse the output as JSON
+      let data = JSON.parse(output);
+
+      // Check if it's an MCP response format: [{"type":"text","text":"..."}]
+      if (Array.isArray(data) && data.length > 0 && data[0].type === 'text' && data[0].text) {
+        // Parse the inner text field which contains the actual Tavily response
+        data = JSON.parse(data[0].text);
+      }
+
+      return data as TavilyResponse;
+    } catch (_e) {
+      return null;
+    }
+  }, [output]);
+
+  // If parsing failed or no results, return null to let parent show raw JSON
+  React.useEffect(() => {
+    if (!parsedData || !parsedData.results || parsedData.results.length === 0) {
+      showFallback?.(true);
+    } else {
+      showFallback?.(false);
+    }
+  }, [parsedData, showFallback]);
+
+  if (!parsedData || !parsedData.results || parsedData.results.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-3 space-y-3">
+      {/* Answer section if available */}
+      {parsedData.answer && (
+        <div className="rounded-lg bg-surface-tertiary p-3">
+          <div className="mb-1.5 text-xs font-semibold text-text-secondary">
+            {localize('com_ui_result')}
+          </div>
+          <div className="text-sm text-text-primary">{parsedData.answer}</div>
+        </div>
+      )}
+
+      {/* Sources section */}
+      <div>
+        <div className="mb-2 text-xs font-semibold text-text-secondary">
+          {localize('com_sources_title')} ({parsedData.results.length})
+        </div>
+        <div className="space-y-2">
+          {parsedData.results.map((result, index) => (
+            <a
+              key={index}
+              href={result.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group block rounded-lg border border-border-light bg-surface-primary-contrast p-3 transition-all duration-200 hover:border-border-medium hover:bg-surface-tertiary hover:shadow-md"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0 flex-1">
+                  {/* Title */}
+                  <div className="mb-1 flex items-center gap-1.5">
+                    <h4 className="line-clamp-1 text-sm font-semibold text-text-primary group-hover:text-blue-600 dark:group-hover:text-blue-400">
+                      {result.title || localize('com_ui_untitled')}
+                    </h4>
+                    <ExternalLink className="h-3 w-3 flex-shrink-0 text-text-secondary opacity-0 transition-opacity group-hover:opacity-100" />
+                  </div>
+
+                  {/* URL */}
+                  <div className="mb-1.5 truncate text-xs text-text-secondary">
+                    {new URL(result.url).hostname}
+                  </div>
+
+                  {/* Content snippet */}
+                  {result.content && (
+                    <p className="line-clamp-2 text-xs text-text-secondary">{result.content}</p>
+                  )}
+                </div>
+
+                {/* Score badge if available */}
+                {result.score !== undefined && (
+                  <div className="flex-shrink-0">
+                    <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
+                      {(result.score * 100).toFixed(0)}%
+                    </span>
+                  </div>
+                )}
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+
+      {/* Images section if available */}
+      {parsedData.images && parsedData.images.length > 0 && (
+        <div>
+          <div className="mb-2 text-xs font-semibold text-text-secondary">
+            {localize('com_sources_tab_images')} ({parsedData.images.length})
+          </div>
+          <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
+            {parsedData.images.slice(0, 6).map((image, index) => (
+              <a
+                key={index}
+                href={image.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group relative aspect-video overflow-hidden rounded-lg bg-surface-secondary"
+              >
+                <img
+                  src={image.url}
+                  alt={
+                    image.description ||
+                    `${localize('com_sources_tab_images')} ${(index + 1).toString()}`
+                  }
+                  className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+                  loading="lazy"
+                />
+                {image.description && (
+                  <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-2">
+                    <p className="line-clamp-1 text-xs text-white">{image.description}</p>
+                  </div>
+                )}
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Follow-up questions if available */}
+      {parsedData.follow_up_questions && parsedData.follow_up_questions.length > 0 && (
+        <div>
+          <div className="mb-2 text-xs font-semibold text-text-secondary">
+            {localize('com_ui_examples')}
+          </div>
+          <div className="space-y-1">
+            {parsedData.follow_up_questions.map((question, index) => (
+              <div
+                key={index}
+                className="rounded-md bg-surface-tertiary px-3 py-2 text-xs text-text-primary"
+              >
+                {question}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/Chat/Messages/Content/TavilySources.tsx
+++ b/client/src/components/Chat/Messages/Content/TavilySources.tsx
@@ -35,14 +35,7 @@ export default function TavilySources({ output, showFallback }: TavilySourcesPro
       let data = JSON.parse(output);
 
       // Check if it's an MCP response format: [{"type":"text","text":"..."}]
-      if (
-        Array.isArray(data) &&
-        data.length > 0 &&
-        data[0] &&
-        typeof data[0] === 'object' &&
-        data[0].type === 'text' &&
-        data[0].text
-      ) {
+      if (Array.isArray(data) && data[0]?.type === 'text' && data[0]?.text) {
         // Parse the inner text field which contains the actual Tavily response
         data = JSON.parse(data[0].text);
       }

--- a/client/src/components/Chat/Messages/Content/TavilySources.tsx
+++ b/client/src/components/Chat/Messages/Content/TavilySources.tsx
@@ -115,7 +115,10 @@ export default function TavilySources({ output, showFallback }: TavilySourcesPro
                 {/* Score badge if available */}
                 {result.score !== undefined && (
                   <div className="flex-shrink-0">
-                    <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
+                    <span
+                      className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-400"
+                      title="Relevance score: how well this result matches your search"
+                    >
                       {(result.score * 100).toFixed(0)}%
                     </span>
                   </div>

--- a/client/src/components/Chat/Messages/Content/TavilySources.tsx
+++ b/client/src/components/Chat/Messages/Content/TavilySources.tsx
@@ -129,41 +129,6 @@ export default function TavilySources({ output, showFallback }: TavilySourcesPro
         </div>
       </div>
 
-      {/* Images section if available */}
-      {parsedData.images && parsedData.images.length > 0 && (
-        <div>
-          <div className="mb-2 text-xs font-semibold text-text-secondary">
-            {localize('com_sources_tab_images')} ({parsedData.images.length})
-          </div>
-          <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
-            {parsedData.images.slice(0, 6).map((image, index) => (
-              <a
-                key={index}
-                href={image.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="group relative aspect-video overflow-hidden rounded-lg bg-surface-secondary"
-              >
-                <img
-                  src={image.url}
-                  alt={
-                    image.description ||
-                    `${localize('com_sources_tab_images')} ${(index + 1).toString()}`
-                  }
-                  className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
-                  loading="lazy"
-                />
-                {image.description && (
-                  <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-2">
-                    <p className="line-clamp-1 text-xs text-white">{image.description}</p>
-                  </div>
-                )}
-              </a>
-            ))}
-          </div>
-        </div>
-      )}
-
       {/* Follow-up questions if available */}
       {parsedData.follow_up_questions && parsedData.follow_up_questions.length > 0 && (
         <div>

--- a/client/src/components/Chat/Messages/Content/TavilySources.tsx
+++ b/client/src/components/Chat/Messages/Content/TavilySources.tsx
@@ -35,7 +35,14 @@ export default function TavilySources({ output, showFallback }: TavilySourcesPro
       let data = JSON.parse(output);
 
       // Check if it's an MCP response format: [{"type":"text","text":"..."}]
-      if (Array.isArray(data) && data.length > 0 && data[0].type === 'text' && data[0].text) {
+      if (
+        Array.isArray(data) &&
+        data.length > 0 &&
+        data[0] &&
+        typeof data[0] === 'object' &&
+        data[0].type === 'text' &&
+        data[0].text
+      ) {
         // Parse the inner text field which contains the actual Tavily response
         data = JSON.parse(data[0].text);
       }
@@ -97,10 +104,16 @@ export default function TavilySources({ output, showFallback }: TavilySourcesPro
 
                   {/* URL */}
                   <div className="mb-1.5 truncate text-xs text-text-secondary">
-                    {new URL(result.url).hostname}
+                    {(() => {
+                      try {
+                        return new URL(result.url).hostname;
+                      } catch {
+                        return result.url;
+                      }
+                    })()}
                   </div>
 
-                  {/* Content snippet */}
+                  {/* Content snippet */
                   {result.content && (
                     <p className="line-clamp-2 text-xs text-text-secondary">{result.content}</p>
                   )}

--- a/client/src/components/Chat/Messages/Content/TavilySources.tsx
+++ b/client/src/components/Chat/Messages/Content/TavilySources.tsx
@@ -113,7 +113,7 @@ export default function TavilySources({ output, showFallback }: TavilySourcesPro
                     })()}
                   </div>
 
-                  {/* Content snippet */
+                  {/* Content snippet */}
                   {result.content && (
                     <p className="line-clamp-2 text-xs text-text-secondary">{result.content}</p>
                   )}

--- a/client/src/components/Chat/Messages/Content/ToolCallInfo.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCallInfo.tsx
@@ -3,6 +3,7 @@ import { useLocalize } from '~/hooks';
 import { Tools } from 'librechat-data-provider';
 import { UIResourceRenderer } from '@mcp-ui/client';
 import UIResourceCarousel from './UIResourceCarousel';
+import TavilySources from './TavilySources';
 import type { TAttachment, UIResource } from 'librechat-data-provider';
 
 function OptimizedCodeBlock({ text, maxHeight = 320 }: { text: string; maxHeight?: number }) {
@@ -64,6 +65,15 @@ export default function ToolCallInfo({
         return attachment[Tools.ui_resources] as UIResource[];
       }) ?? [];
 
+  // Check if this is a Tavily search tool call
+  // Legacy plugin: function_name === 'tavily_search_results_json'
+  // MCP tool: domain includes 'tavily' (e.g., "Internet Search (Tavily)")
+  const isTavilySearch =
+    function_name === 'tavily_search_results_json' ||
+    (domain != null && domain.toLowerCase().includes('tavily'));
+
+  const [showFallback, setShowFallback] = React.useState(false);
+
   return (
     <div className="w-full p-2">
       <div style={{ opacity: 1 }}>
@@ -77,7 +87,11 @@ export default function ToolCallInfo({
               {localize('com_ui_result')}
             </div>
             <div>
-              <OptimizedCodeBlock text={formatText(output)} maxHeight={250} />
+              {isTavilySearch && !showFallback ? (
+                <TavilySources output={output} showFallback={setShowFallback} />
+              ) : (
+                <OptimizedCodeBlock text={formatText(output)} maxHeight={250} />
+              )}
             </div>
             {uiResources.length > 0 && (
               <div className="my-2 text-sm font-medium text-text-primary">

--- a/client/src/components/Chat/Messages/Content/__tests__/TavilySources.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/TavilySources.test.tsx
@@ -1,0 +1,478 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TavilySources from '../TavilySources';
+
+// Mock dependencies
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string, values?: any) => {
+    const translations: Record<string, string> = {
+      com_ui_result: 'Result',
+      com_ui_untitled: 'Untitled',
+      com_sources_title: 'Sources',
+      com_sources_tab_images: 'Images',
+      com_ui_examples: 'Examples',
+    };
+    return translations[key] || key;
+  },
+}));
+
+jest.mock('lucide-react', () => ({
+  ExternalLink: () => <span data-testid="external-link-icon">ExternalLink</span>,
+}));
+
+describe('TavilySources', () => {
+  const mockShowFallback = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('JSON Parsing', () => {
+    it('should parse standard Tavily JSON response', () => {
+      const output = JSON.stringify({
+        query: 'test query',
+        answer: 'Test answer',
+        results: [
+          {
+            title: 'Test Result',
+            url: 'https://example.com',
+            content: 'Test content',
+            score: 0.95,
+          },
+        ],
+      });
+
+      render(<TavilySources output={output} showFallback={mockShowFallback} />);
+
+      expect(screen.getByText('Test answer')).toBeInTheDocument();
+      expect(screen.getByText('Test Result')).toBeInTheDocument();
+      expect(mockShowFallback).toHaveBeenCalledWith(false);
+    });
+
+    it('should parse MCP response format with nested JSON', () => {
+      const tavilyResponse = {
+        results: [
+          {
+            title: 'MCP Result',
+            url: 'https://mcp-test.com',
+            content: 'MCP content',
+          },
+        ],
+      };
+
+      const mcpOutput = JSON.stringify([
+        {
+          type: 'text',
+          text: JSON.stringify(tavilyResponse),
+        },
+      ]);
+
+      render(<TavilySources output={mcpOutput} showFallback={mockShowFallback} />);
+
+      expect(screen.getByText('MCP Result')).toBeInTheDocument();
+      expect(screen.getByText('MCP content')).toBeInTheDocument();
+      expect(mockShowFallback).toHaveBeenCalledWith(false);
+    });
+
+    it('should return null and trigger fallback for invalid JSON', () => {
+      const { container } = render(
+        <TavilySources output="invalid json" showFallback={mockShowFallback} />,
+      );
+
+      expect(container.firstChild).toBeNull();
+      expect(mockShowFallback).toHaveBeenCalledWith(true);
+    });
+
+    it('should return null and trigger fallback when results array is empty', () => {
+      const output = JSON.stringify({
+        query: 'test',
+        results: [],
+      });
+
+      const { container } = render(
+        <TavilySources output={output} showFallback={mockShowFallback} />,
+      );
+
+      expect(container.firstChild).toBeNull();
+      expect(mockShowFallback).toHaveBeenCalledWith(true);
+    });
+
+    it('should return null and trigger fallback when results field is missing', () => {
+      const output = JSON.stringify({
+        query: 'test',
+        answer: 'Some answer',
+      });
+
+      const { container } = render(
+        <TavilySources output={output} showFallback={mockShowFallback} />,
+      );
+
+      expect(container.firstChild).toBeNull();
+      expect(mockShowFallback).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('Answer Section Rendering', () => {
+    it('should render answer section when answer is provided', () => {
+      const output = JSON.stringify({
+        answer: 'This is the answer',
+        results: [{ url: 'https://example.com' }],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.getByText('Result')).toBeInTheDocument();
+      expect(screen.getByText('This is the answer')).toBeInTheDocument();
+    });
+
+    it('should not render answer section when answer is missing', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.queryByText('Result')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Sources Section Rendering', () => {
+    it('should render multiple search results with correct count', () => {
+      const output = JSON.stringify({
+        results: [
+          { title: 'Result 1', url: 'https://example1.com', content: 'Content 1' },
+          { title: 'Result 2', url: 'https://example2.com', content: 'Content 2' },
+          { title: 'Result 3', url: 'https://example3.com', content: 'Content 3' },
+        ],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.getByText('Sources (3)')).toBeInTheDocument();
+      expect(screen.getByText('Result 1')).toBeInTheDocument();
+      expect(screen.getByText('Result 2')).toBeInTheDocument();
+      expect(screen.getByText('Result 3')).toBeInTheDocument();
+    });
+
+    it('should render clickable links with correct href and attributes', () => {
+      const output = JSON.stringify({
+        results: [{ title: 'Clickable Result', url: 'https://test.example.com/page' }],
+      });
+
+      render(<TavilySources output={output} />);
+
+      const link = screen.getByRole('link', { name: /Clickable Result/i });
+      expect(link).toHaveAttribute('href', 'https://test.example.com/page');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('should display hostname extracted from URL', () => {
+      const output = JSON.stringify({
+        results: [{ title: 'Test', url: 'https://subdomain.example.com/path/to/page?query=1' }],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.getByText('subdomain.example.com')).toBeInTheDocument();
+    });
+
+    it('should display full URL when hostname extraction fails', () => {
+      const output = JSON.stringify({
+        results: [{ title: 'Test', url: 'invalid-url' }],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.getByText('invalid-url')).toBeInTheDocument();
+    });
+
+    it('should render "Untitled" when title is missing', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.getByText('Untitled')).toBeInTheDocument();
+    });
+
+    it('should render content snippet when available', () => {
+      const output = JSON.stringify({
+        results: [
+          {
+            title: 'Test',
+            url: 'https://example.com',
+            content: 'This is a content snippet',
+          },
+        ],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.getByText('This is a content snippet')).toBeInTheDocument();
+    });
+
+    it('should not render content snippet when missing', () => {
+      const output = JSON.stringify({
+        results: [{ title: 'Test', url: 'https://example.com' }],
+      });
+
+      const { container } = render(<TavilySources output={output} />);
+
+      // Should not have paragraph with content class
+      const contentParagraph = container.querySelector('p.line-clamp-2');
+      expect(contentParagraph).not.toBeInTheDocument();
+    });
+
+    it('should render score badge when score is provided', () => {
+      const output = JSON.stringify({
+        results: [{ title: 'Test', url: 'https://example.com', score: 0.8567 }],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.getByText('86%')).toBeInTheDocument();
+    });
+
+    it('should not render score badge when score is missing', () => {
+      const output = JSON.stringify({
+        results: [{ title: 'Test', url: 'https://example.com' }],
+      });
+
+      const { container } = render(<TavilySources output={output} />);
+
+      // Should not have score span
+      const scoreBadge = container.querySelector('span.inline-flex');
+      expect(scoreBadge).not.toBeInTheDocument();
+    });
+
+    it('should render ExternalLink icon for each result', () => {
+      const output = JSON.stringify({
+        results: [
+          { title: 'Result 1', url: 'https://example1.com' },
+          { title: 'Result 2', url: 'https://example2.com' },
+        ],
+      });
+
+      render(<TavilySources output={output} />);
+
+      const icons = screen.getAllByTestId('external-link-icon');
+      expect(icons).toHaveLength(2);
+    });
+  });
+
+  describe('Images Section Rendering', () => {
+    it('should render images section with correct count', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+        images: [
+          { url: 'https://img1.com/pic1.jpg', description: 'Image 1' },
+          { url: 'https://img2.com/pic2.jpg', description: 'Image 2' },
+        ],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.getByText('Images (2)')).toBeInTheDocument();
+    });
+
+    it('should limit images to maximum of 6', () => {
+      const images = Array.from({ length: 10 }, (_, i) => ({
+        url: `https://img${i}.com/pic${i}.jpg`,
+      }));
+
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+        images,
+      });
+
+      render(<TavilySources output={output} />);
+
+      // Should show "Images (10)" but only render 6 img tags
+      expect(screen.getByText('Images (10)')).toBeInTheDocument();
+      const imgElements = screen.getAllByRole('img');
+      expect(imgElements).toHaveLength(6);
+    });
+
+    it('should render image with description overlay', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+        images: [{ url: 'https://img.com/pic.jpg', description: 'Beautiful sunset' }],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.getByText('Beautiful sunset')).toBeInTheDocument();
+      expect(screen.getByAltText('Beautiful sunset')).toBeInTheDocument();
+    });
+
+    it('should render image without description overlay when missing', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+        images: [{ url: 'https://img.com/pic.jpg' }],
+      });
+
+      const { container } = render(<TavilySources output={output} />);
+
+      // Should have img but no description overlay
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      const overlay = container.querySelector('.absolute.inset-x-0.bottom-0');
+      expect(overlay).not.toBeInTheDocument();
+    });
+
+    it('should use fallback alt text when description is missing', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+        images: [{ url: 'https://img.com/pic.jpg' }],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.getByAltText('Images 1')).toBeInTheDocument();
+    });
+
+    it('should not render images section when images array is empty', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+        images: [],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.queryByText(/Images/i)).not.toBeInTheDocument();
+    });
+
+    it('should not render images section when images field is missing', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.queryByText(/Images/i)).not.toBeInTheDocument();
+    });
+
+    it('should render image links with correct attributes', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+        images: [{ url: 'https://img.com/pic.jpg' }],
+      });
+
+      const { container } = render(<TavilySources output={output} />);
+
+      const imageLink = container.querySelector('a[href="https://img.com/pic.jpg"]');
+      expect(imageLink).toBeInTheDocument();
+      expect(imageLink).toHaveAttribute('target', '_blank');
+      expect(imageLink).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+  });
+
+  describe('Follow-up Questions Rendering', () => {
+    it('should render follow-up questions section', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+        follow_up_questions: ['Question 1?', 'Question 2?', 'Question 3?'],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.getByText('Examples')).toBeInTheDocument();
+      expect(screen.getByText('Question 1?')).toBeInTheDocument();
+      expect(screen.getByText('Question 2?')).toBeInTheDocument();
+      expect(screen.getByText('Question 3?')).toBeInTheDocument();
+    });
+
+    it('should not render follow-up questions when array is empty', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+        follow_up_questions: [],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.queryByText('Examples')).not.toBeInTheDocument();
+    });
+
+    it('should not render follow-up questions when field is missing', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.queryByText('Examples')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Complete Response Rendering', () => {
+    it('should render all sections when complete Tavily response is provided', () => {
+      const output = JSON.stringify({
+        query: 'test query',
+        answer: 'Complete answer',
+        results: [
+          {
+            title: 'Complete Result',
+            url: 'https://example.com',
+            content: 'Complete content',
+            score: 0.95,
+          },
+        ],
+        images: [{ url: 'https://img.com/pic.jpg', description: 'Test image' }],
+        follow_up_questions: ['Follow-up question?'],
+        response_time: 1.23,
+      });
+
+      render(<TavilySources output={output} />);
+
+      // Check all sections are rendered
+      expect(screen.getByText('Complete answer')).toBeInTheDocument();
+      expect(screen.getByText('Complete Result')).toBeInTheDocument();
+      expect(screen.getByText('Images (1)')).toBeInTheDocument();
+      expect(screen.getByText('Examples')).toBeInTheDocument();
+      expect(screen.getByText('Follow-up question?')).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle showFallback being undefined', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+      });
+
+      // Should not throw error
+      expect(() => render(<TavilySources output={output} />)).not.toThrow();
+    });
+
+    it('should handle result with all optional fields missing', () => {
+      const output = JSON.stringify({
+        results: [{ url: 'https://example.com' }],
+      });
+
+      const { container } = render(<TavilySources output={output} />);
+
+      expect(screen.getByText('Untitled')).toBeInTheDocument();
+      expect(container.querySelector('a[href="https://example.com"]')).toBeInTheDocument();
+    });
+
+    it('should handle score of 0', () => {
+      const output = JSON.stringify({
+        results: [{ title: 'Test', url: 'https://example.com', score: 0 }],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.getByText('0%')).toBeInTheDocument();
+    });
+
+    it('should handle score of 1', () => {
+      const output = JSON.stringify({
+        results: [{ title: 'Test', url: 'https://example.com', score: 1.0 }],
+      });
+
+      render(<TavilySources output={output} />);
+
+      expect(screen.getByText('100%')).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/Chat/Messages/Content/__tests__/TavilySources.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/TavilySources.test.tsx
@@ -4,7 +4,7 @@ import TavilySources from '../TavilySources';
 
 // Mock dependencies
 jest.mock('~/hooks', () => ({
-  useLocalize: () => (key: string, values?: any) => {
+  useLocalize: () => (key: string, _values?: any) => {
     const translations: Record<string, string> = {
       com_ui_result: 'Result',
       com_ui_untitled: 'Untitled',
@@ -17,6 +17,7 @@ jest.mock('~/hooks', () => ({
 }));
 
 jest.mock('lucide-react', () => ({
+  // eslint-disable-next-line i18next/no-literal-string
   ExternalLink: () => <span data-testid="external-link-icon">ExternalLink</span>,
 }));
 
@@ -232,7 +233,12 @@ describe('TavilySources', () => {
 
       render(<TavilySources output={output} />);
 
-      expect(screen.getByText('86%')).toBeInTheDocument();
+      const scoreBadge = screen.getByText('86%');
+      expect(scoreBadge).toBeInTheDocument();
+      expect(scoreBadge).toHaveAttribute(
+        'title',
+        'Relevance score: how well this result matches your search',
+      );
     });
 
     it('should not render score badge when score is missing', () => {
@@ -462,7 +468,12 @@ describe('TavilySources', () => {
 
       render(<TavilySources output={output} />);
 
-      expect(screen.getByText('0%')).toBeInTheDocument();
+      const scoreBadge = screen.getByText('0%');
+      expect(scoreBadge).toBeInTheDocument();
+      expect(scoreBadge).toHaveAttribute(
+        'title',
+        'Relevance score: how well this result matches your search',
+      );
     });
 
     it('should handle score of 1', () => {
@@ -472,7 +483,12 @@ describe('TavilySources', () => {
 
       render(<TavilySources output={output} />);
 
-      expect(screen.getByText('100%')).toBeInTheDocument();
+      const scoreBadge = screen.getByText('100%');
+      expect(scoreBadge).toBeInTheDocument();
+      expect(scoreBadge).toHaveAttribute(
+        'title',
+        'Relevance score: how well this result matches your search',
+      );
     });
   });
 });

--- a/client/src/components/Chat/Messages/Content/__tests__/TavilySources.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/TavilySources.test.tsx
@@ -9,7 +9,6 @@ jest.mock('~/hooks', () => ({
       com_ui_result: 'Result',
       com_ui_untitled: 'Untitled',
       com_sources_title: 'Sources',
-      com_sources_tab_images: 'Images',
       com_ui_examples: 'Examples',
     };
     return translations[key] || key;
@@ -268,112 +267,6 @@ describe('TavilySources', () => {
     });
   });
 
-  describe('Images Section Rendering', () => {
-    it('should render images section with correct count', () => {
-      const output = JSON.stringify({
-        results: [{ url: 'https://example.com' }],
-        images: [
-          { url: 'https://img1.com/pic1.jpg', description: 'Image 1' },
-          { url: 'https://img2.com/pic2.jpg', description: 'Image 2' },
-        ],
-      });
-
-      render(<TavilySources output={output} />);
-
-      expect(screen.getByText('Images (2)')).toBeInTheDocument();
-    });
-
-    it('should limit images to maximum of 6', () => {
-      const images = Array.from({ length: 10 }, (_, i) => ({
-        url: `https://img${i}.com/pic${i}.jpg`,
-      }));
-
-      const output = JSON.stringify({
-        results: [{ url: 'https://example.com' }],
-        images,
-      });
-
-      render(<TavilySources output={output} />);
-
-      // Should show "Images (10)" but only render 6 img tags
-      expect(screen.getByText('Images (10)')).toBeInTheDocument();
-      const imgElements = screen.getAllByRole('img');
-      expect(imgElements).toHaveLength(6);
-    });
-
-    it('should render image with description overlay', () => {
-      const output = JSON.stringify({
-        results: [{ url: 'https://example.com' }],
-        images: [{ url: 'https://img.com/pic.jpg', description: 'Beautiful sunset' }],
-      });
-
-      render(<TavilySources output={output} />);
-
-      expect(screen.getByText('Beautiful sunset')).toBeInTheDocument();
-      expect(screen.getByAltText('Beautiful sunset')).toBeInTheDocument();
-    });
-
-    it('should render image without description overlay when missing', () => {
-      const output = JSON.stringify({
-        results: [{ url: 'https://example.com' }],
-        images: [{ url: 'https://img.com/pic.jpg' }],
-      });
-
-      const { container } = render(<TavilySources output={output} />);
-
-      // Should have img but no description overlay
-      expect(screen.getByRole('img')).toBeInTheDocument();
-      const overlay = container.querySelector('.absolute.inset-x-0.bottom-0');
-      expect(overlay).not.toBeInTheDocument();
-    });
-
-    it('should use fallback alt text when description is missing', () => {
-      const output = JSON.stringify({
-        results: [{ url: 'https://example.com' }],
-        images: [{ url: 'https://img.com/pic.jpg' }],
-      });
-
-      render(<TavilySources output={output} />);
-
-      expect(screen.getByAltText('Images 1')).toBeInTheDocument();
-    });
-
-    it('should not render images section when images array is empty', () => {
-      const output = JSON.stringify({
-        results: [{ url: 'https://example.com' }],
-        images: [],
-      });
-
-      render(<TavilySources output={output} />);
-
-      expect(screen.queryByText(/Images/i)).not.toBeInTheDocument();
-    });
-
-    it('should not render images section when images field is missing', () => {
-      const output = JSON.stringify({
-        results: [{ url: 'https://example.com' }],
-      });
-
-      render(<TavilySources output={output} />);
-
-      expect(screen.queryByText(/Images/i)).not.toBeInTheDocument();
-    });
-
-    it('should render image links with correct attributes', () => {
-      const output = JSON.stringify({
-        results: [{ url: 'https://example.com' }],
-        images: [{ url: 'https://img.com/pic.jpg' }],
-      });
-
-      const { container } = render(<TavilySources output={output} />);
-
-      const imageLink = container.querySelector('a[href="https://img.com/pic.jpg"]');
-      expect(imageLink).toBeInTheDocument();
-      expect(imageLink).toHaveAttribute('target', '_blank');
-      expect(imageLink).toHaveAttribute('rel', 'noopener noreferrer');
-    });
-  });
-
   describe('Follow-up Questions Rendering', () => {
     it('should render follow-up questions section', () => {
       const output = JSON.stringify({
@@ -431,12 +324,13 @@ describe('TavilySources', () => {
 
       render(<TavilySources output={output} />);
 
-      // Check all sections are rendered
+      // Check all sections are rendered (images excluded)
       expect(screen.getByText('Complete answer')).toBeInTheDocument();
       expect(screen.getByText('Complete Result')).toBeInTheDocument();
-      expect(screen.getByText('Images (1)')).toBeInTheDocument();
       expect(screen.getByText('Examples')).toBeInTheDocument();
       expect(screen.getByText('Follow-up question?')).toBeInTheDocument();
+      // Images should not be rendered
+      expect(screen.queryByText(/Images/i)).not.toBeInTheDocument();
     });
   });
 

--- a/client/src/hooks/MCP/__tests__/useMCPSelect.test.tsx
+++ b/client/src/hooks/MCP/__tests__/useMCPSelect.test.tsx
@@ -7,6 +7,7 @@ import { Constants, LocalStorageKeys } from 'librechat-data-provider';
 import { ephemeralAgentByConvoId } from '~/store';
 import { setTimestamp } from '~/utils/timestamps';
 import { useMCPSelect } from '../useMCPSelect';
+import * as dataProvider from '~/data-provider';
 
 // Mock dependencies
 jest.mock('~/utils/timestamps', () => ({
@@ -512,7 +513,7 @@ describe('useMCPSelect', () => {
   });
 
   describe('Auto-Select Functionality', () => {
-    const useGetStartupConfig = require('~/data-provider').useGetStartupConfig;
+    const useGetStartupConfig = jest.spyOn(dataProvider, 'useGetStartupConfig');
 
     it('should auto-select MCP servers with startup: true on new conversations', async () => {
       // Mock config with a startup server
@@ -621,29 +622,12 @@ describe('useMCPSelect', () => {
         },
       });
 
-      // Start with existing MCP values
-      const TestComponent = () => {
-        const [ephemeralAgent, setEphemeralAgent] = useRecoilState(
-          ephemeralAgentByConvoId(Constants.NEW_CONVO),
-        );
-        const result = useMCPSelect({});
-
-        React.useEffect(() => {
-          setEphemeralAgent({ mcp: ['Existing Server'] });
-        }, [setEphemeralAgent]);
-
-        return null;
-      };
-
-      const { rerender } = renderHook(() => useMCPSelect({}), {
+      const { result } = renderHook(() => useMCPSelect({}), {
         wrapper: createWrapper(),
       });
 
       // Initially should auto-select
       await waitFor(() => {
-        const { result } = renderHook(() => useMCPSelect({}), {
-          wrapper: createWrapper(),
-        });
         expect(result.current.mcpValues).toEqual(['Startup Server']);
       });
     });

--- a/client/src/hooks/MCP/useMCPSelect.ts
+++ b/client/src/hooks/MCP/useMCPSelect.ts
@@ -52,7 +52,8 @@ export function useMCPSelect({ conversationId }: { conversationId?: string | nul
     if (startupServers.length > 0) {
       setMCPValuesRaw(startupServers);
     }
-  }, [key, startupConfig, mcpValues.length, setMCPValuesRaw]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, startupConfig?.mcpServers, setMCPValuesRaw]);
 
   /** Stable memoized setter */
   const setMCPValues = useCallback(

--- a/client/src/hooks/MCP/useMCPSelect.ts
+++ b/client/src/hooks/MCP/useMCPSelect.ts
@@ -4,10 +4,12 @@ import isEqual from 'lodash/isEqual';
 import { useRecoilState } from 'recoil';
 import { Constants, LocalStorageKeys } from 'librechat-data-provider';
 import { ephemeralAgentByConvoId, mcpValuesAtomFamily, mcpPinnedAtom } from '~/store';
+import { useGetStartupConfig } from '~/data-provider';
 import { setTimestamp } from '~/utils/timestamps';
 
 export function useMCPSelect({ conversationId }: { conversationId?: string | null }) {
   const key = conversationId ?? Constants.NEW_CONVO;
+  const { data: startupConfig } = useGetStartupConfig();
 
   const [isPinned, setIsPinned] = useAtom(mcpPinnedAtom);
   const [mcpValues, setMCPValuesRaw] = useAtom(mcpValuesAtomFamily(key));
@@ -35,6 +37,22 @@ export function useMCPSelect({ conversationId }: { conversationId?: string | nul
       setTimestamp(mcpStorageKey);
     }
   }, [mcpValues, key]);
+
+  // Auto-select MCP servers configured with startup: true for new conversations
+  useEffect(() => {
+    if (mcpValues.length > 0) return; // Already has selections
+    if (key !== Constants.NEW_CONVO) return; // Only for new conversations
+    if (!startupConfig?.mcpServers) return; // No MCP servers configured
+
+    // Get servers configured with startup: true and visible in chat menu
+    const startupServers = Object.entries(startupConfig.mcpServers)
+      .filter(([, config]) => config.startup === true && config.chatMenu !== false)
+      .map(([serverName]) => serverName);
+
+    if (startupServers.length > 0) {
+      setMCPValuesRaw(startupServers);
+    }
+  }, [key, startupConfig, mcpValues.length, setMCPValuesRaw]);
 
   /** Stable memoized setter */
   const setMCPValues = useCallback(

--- a/client/src/hooks/MCP/useMCPSelect.ts
+++ b/client/src/hooks/MCP/useMCPSelect.ts
@@ -41,19 +41,22 @@ export function useMCPSelect({ conversationId }: { conversationId?: string | nul
   // Auto-select MCP servers configured with startup: true for new conversations
   useEffect(() => {
     if (mcpValues.length > 0) return; // Already has selections
-    if (key !== Constants.NEW_CONVO) return; // Only for new conversations
     if (!startupConfig?.mcpServers) return; // No MCP servers configured
 
-    // Get servers configured with startup: true and visible in chat menu
+    // Auto-select for "new" conversations OR for conversations that have never had MCP configured
+    const shouldAutoSelect = key === Constants.NEW_CONVO || ephemeralAgent?.mcp?.length === 0;
+    if (!shouldAutoSelect) return;
+
+    // Get servers configured with startup: true (chatMenu setting only affects UI visibility, not auto-selection)
     const startupServers = Object.entries(startupConfig.mcpServers)
-      .filter(([, config]) => config.startup === true && config.chatMenu !== false)
+      .filter(([, config]) => config.startup === true)
       .map(([serverName]) => serverName);
 
     if (startupServers.length > 0) {
       setMCPValuesRaw(startupServers);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key, startupConfig?.mcpServers, setMCPValuesRaw]);
+  }, [key, startupConfig?.mcpServers, setMCPValuesRaw, ephemeralAgent?.mcp?.length]);
 
   /** Stable memoized setter */
   const setMCPValues = useCallback(

--- a/librechat.n1.yml
+++ b/librechat.n1.yml
@@ -9,9 +9,9 @@ interface:
 modelSpecs:
   addedEndpoints:
     - azureOpenAI
-    - 'Gemini 2.5 Pro'
-    - 'Gemini 2.5 Flash'
-    - 'Claude Sonnet 4.5'
+    - "Gemini 2.5 Pro"
+    - "Gemini 2.5 Flash"
+    - "Claude Sonnet 4.5"
   list:
     - name: azure-gpt-4o
       label: GPT-4o
@@ -48,102 +48,102 @@ modelSpecs:
       label: Gemini 2.5 Pro
       description: Quickly analyze complex, mixed media content.
       preset:
-        endpoint: 'Gemini 2.5 Pro'
+        endpoint: "Gemini 2.5 Pro"
         model: gemini-2.5-pro
     - name: google-gemini-25-flash
       label: Gemini 2.5 Flash
       description: A faster, more lightweight version of Gemini 2.5 Pro.
       preset:
-        endpoint: 'Gemini 2.5 Flash'
+        endpoint: "Gemini 2.5 Flash"
         model: gemini-2.5-flash
     - name: anthropic-claude-sonnet-45
       label: Claude Sonnet 4.5 (Limited)
       description: For extended reasoning, coding, and automation. This model is being evaluated. It can be used a limited number of times.
       preset:
-        endpoint: 'Claude Sonnet 4.5'
+        endpoint: "Claude Sonnet 4.5"
         model: claude-sonnet-4-5
 mcpServers:
   Internet Search (Tavily):
     type: streamable-http
     url: https://mcp.tavily.com/mcp/
     headers:
-      Authorization: 'Bearer ${TAVILY_API_KEY}'
+      Authorization: "Bearer ${TAVILY_API_KEY}"
     startup: true
     chatMenu: false
     requiresOAuth: false
 endpoints:
   azureOpenAI:
     # Endpoint-level configuration
-    titleModel: 'gpt-4o'
+    titleModel: "gpt-4o"
     plugins: false
     assistants: false
     groups:
       # Group-level configuration
-      - group: 'NP East US'
-        instanceName: 'NP OpenAI'
-        apiKey: '${AZURE_OPENAI_API_KEY}'
-        baseURL: '${AZURE_OPENAI_BASEURL}'
-        version: '2024-10-21'
+      - group: "NP East US"
+        instanceName: "NP OpenAI"
+        apiKey: "${AZURE_OPENAI_API_KEY}"
+        baseURL: "${AZURE_OPENAI_BASEURL}"
+        version: "2024-10-21"
         # Model-level configuration
         models:
           gpt-5:
             deploymentName: gpt-5
-            version: '2024-10-21'
+            version: "2024-10-21"
           gpt-4o:
             deploymentName: gpt-4o
-            version: '2024-10-21'
+            version: "2024-10-21"
           gpt-4o-mini:
             deploymentName: gpt-4o-mini
-            version: '2024-10-21'
+            version: "2024-10-21"
           gpt-41:
             deploymentName: gpt-41
-            version: '2024-10-21'
+            version: "2024-10-21"
           gpt-41-mini:
             deploymentName: gpt-41-mini
-            version: '2024-10-21'
+            version: "2024-10-21"
   custom:
-    - name: 'Gemini 2.5 Pro'
-      apiKey: '${GCP_VERTEXAI_API_KEY}'
-      baseURL: '${GCP_VERTEXAI_BASEURL}/gemini-2.5-pro/v1'
+    - name: "Gemini 2.5 Pro"
+      apiKey: "${GCP_VERTEXAI_API_KEY}"
+      baseURL: "${GCP_VERTEXAI_BASEURL}/gemini-2.5-pro/v1"
       directEndpoint: true
       models:
         default:
           - gemini-2.5-pro
-      titleModel: 'gemini-2.5-pro'
+      titleModel: "gemini-2.5-pro"
       titleConvo: true
-      modelDisplayLabel: 'gemini-2.5-pro'
+      modelDisplayLabel: "gemini-2.5-pro"
       addParams:
         streaming: false
         disableStreaming: true
       dropParams:
         - stream
         - streaming
-    - name: 'Gemini 2.5 Flash'
-      apiKey: '${GCP_VERTEXAI_API_KEY}'
-      baseURL: '${GCP_VERTEXAI_BASEURL}/gemini-2.5-flash/v1'
+    - name: "Gemini 2.5 Flash"
+      apiKey: "${GCP_VERTEXAI_API_KEY}"
+      baseURL: "${GCP_VERTEXAI_BASEURL}/gemini-2.5-flash/v1"
       directEndpoint: true
       models:
         default:
           - gemini-2.5-flash
-      titleModel: 'gemini-2.5-flash'
+      titleModel: "gemini-2.5-flash"
       titleConvo: true
-      modelDisplayLabel: 'gemini-2.5-flash'
+      modelDisplayLabel: "gemini-2.5-flash"
       addParams:
         streaming: false
         disableStreaming: true
       dropParams:
         - stream
         - streaming
-    - name: 'Claude Sonnet 4.5'
-      apiKey: '${GCP_VERTEXAI_API_KEY}'
-      baseURL: '${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1'
+    - name: "Claude Sonnet 4.5"
+      apiKey: "${GCP_VERTEXAI_API_KEY}"
+      baseURL: "${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1"
       directEndpoint: true
       models:
         default:
           - claude-sonnet-4-5
-      titleModel: 'claude-sonnet-4-5'
+      titleModel: "claude-sonnet-4-5"
       titleConvo: true
-      modelDisplayLabel: 'claude-sonnet-4-5'
+      modelDisplayLabel: "claude-sonnet-4-5"
       addParams:
         streaming: false
         disableStreaming: true

--- a/librechat.n1.yml
+++ b/librechat.n1.yml
@@ -9,9 +9,9 @@ interface:
 modelSpecs:
   addedEndpoints:
     - azureOpenAI
-    - "Gemini 2.5 Pro"
-    - "Gemini 2.5 Flash"
-    - "Claude Sonnet 4.5"
+    - 'Gemini 2.5 Pro'
+    - 'Gemini 2.5 Flash'
+    - 'Claude Sonnet 4.5'
   list:
     - name: azure-gpt-4o
       label: GPT-4o
@@ -48,99 +48,102 @@ modelSpecs:
       label: Gemini 2.5 Pro
       description: Quickly analyze complex, mixed media content.
       preset:
-        endpoint: "Gemini 2.5 Pro"
+        endpoint: 'Gemini 2.5 Pro'
         model: gemini-2.5-pro
     - name: google-gemini-25-flash
       label: Gemini 2.5 Flash
       description: A faster, more lightweight version of Gemini 2.5 Pro.
       preset:
-        endpoint: "Gemini 2.5 Flash"
+        endpoint: 'Gemini 2.5 Flash'
         model: gemini-2.5-flash
     - name: anthropic-claude-sonnet-45
       label: Claude Sonnet 4.5 (Limited)
       description: For extended reasoning, coding, and automation. This model is being evaluated. It can be used a limited number of times.
       preset:
-        endpoint: "Claude Sonnet 4.5"
+        endpoint: 'Claude Sonnet 4.5'
         model: claude-sonnet-4-5
 mcpServers:
   Internet Search (Tavily):
     type: streamable-http
     url: https://mcp.tavily.com/mcp/
     headers:
-      Authorization: "Bearer ${TAVILY_API_KEY}"
+      Authorization: 'Bearer ${TAVILY_API_KEY}'
+    startup: true
+    chatMenu: false
+    requiresOAuth: false
 endpoints:
   azureOpenAI:
     # Endpoint-level configuration
-    titleModel: "gpt-4o"
+    titleModel: 'gpt-4o'
     plugins: false
     assistants: false
     groups:
-    # Group-level configuration
-    - group: "NP East US"
-      instanceName: "NP OpenAI"
-      apiKey: "${AZURE_OPENAI_API_KEY}"
-      baseURL: "${AZURE_OPENAI_BASEURL}"
-      version: "2024-10-21"
-      # Model-level configuration
-      models:
-        gpt-5:
-          deploymentName: gpt-5
-          version: "2024-10-21"
-        gpt-4o:
-          deploymentName: gpt-4o
-          version: "2024-10-21"
-        gpt-4o-mini:
-          deploymentName: gpt-4o-mini
-          version: "2024-10-21"
-        gpt-41:
-          deploymentName: gpt-41
-          version: "2024-10-21"
-        gpt-41-mini:
-          deploymentName: gpt-41-mini
-          version: "2024-10-21"
+      # Group-level configuration
+      - group: 'NP East US'
+        instanceName: 'NP OpenAI'
+        apiKey: '${AZURE_OPENAI_API_KEY}'
+        baseURL: '${AZURE_OPENAI_BASEURL}'
+        version: '2024-10-21'
+        # Model-level configuration
+        models:
+          gpt-5:
+            deploymentName: gpt-5
+            version: '2024-10-21'
+          gpt-4o:
+            deploymentName: gpt-4o
+            version: '2024-10-21'
+          gpt-4o-mini:
+            deploymentName: gpt-4o-mini
+            version: '2024-10-21'
+          gpt-41:
+            deploymentName: gpt-41
+            version: '2024-10-21'
+          gpt-41-mini:
+            deploymentName: gpt-41-mini
+            version: '2024-10-21'
   custom:
-    - name: "Gemini 2.5 Pro"
-      apiKey: "${GCP_VERTEXAI_API_KEY}"
-      baseURL: "${GCP_VERTEXAI_BASEURL}/gemini-2.5-pro/v1"
+    - name: 'Gemini 2.5 Pro'
+      apiKey: '${GCP_VERTEXAI_API_KEY}'
+      baseURL: '${GCP_VERTEXAI_BASEURL}/gemini-2.5-pro/v1'
       directEndpoint: true
       models:
         default:
           - gemini-2.5-pro
-      titleModel: "gemini-2.5-pro"
+      titleModel: 'gemini-2.5-pro'
       titleConvo: true
-      modelDisplayLabel: "gemini-2.5-pro"
+      modelDisplayLabel: 'gemini-2.5-pro'
       addParams:
         streaming: false
         disableStreaming: true
       dropParams:
         - stream
         - streaming
-    - name: "Gemini 2.5 Flash"
-      apiKey: "${GCP_VERTEXAI_API_KEY}"
-      baseURL: "${GCP_VERTEXAI_BASEURL}/gemini-2.5-flash/v1"
+    - name: 'Gemini 2.5 Flash'
+      apiKey: '${GCP_VERTEXAI_API_KEY}'
+      baseURL: '${GCP_VERTEXAI_BASEURL}/gemini-2.5-flash/v1'
       directEndpoint: true
       models:
         default:
           - gemini-2.5-flash
-      titleModel: "gemini-2.5-flash"
+      titleModel: 'gemini-2.5-flash'
       titleConvo: true
-      modelDisplayLabel: "gemini-2.5-flash"
+      modelDisplayLabel: 'gemini-2.5-flash'
       addParams:
         streaming: false
         disableStreaming: true
       dropParams:
         - stream
         - streaming
-    - name: "Claude Sonnet 4.5"
-      apiKey: "${GCP_VERTEXAI_API_KEY}"
-      baseURL: "${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1"
+    - name: 'Claude Sonnet 4.5'
+      apiKey: '${GCP_VERTEXAI_API_KEY}'
+      baseURL: '${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1'
       directEndpoint: true
       models:
         default:
           - claude-sonnet-4-5
-      titleModel: "claude-sonnet-4-5"
+      titleModel: 'claude-sonnet-4-5'
       titleConvo: true
-      modelDisplayLabel: "claude-sonnet-4-5"
+      modelDisplayLabel: 'claude-sonnet-4-5'
       addParams:
         streaming: false
         disableStreaming: true

--- a/librechat.n2a.yml
+++ b/librechat.n2a.yml
@@ -10,9 +10,9 @@ interface:
 modelSpecs:
   addedEndpoints:
     - azureOpenAI
-    - 'Gemini 2.5 Pro'
-    - 'Gemini 2.5 Flash'
-    - 'Claude Sonnet 4.5'
+    - "Gemini 2.5 Pro"
+    - "Gemini 2.5 Flash"
+    - "Claude Sonnet 4.5"
   list:
     - name: azure-gpt-4o
       label: GPT-4o
@@ -49,102 +49,102 @@ modelSpecs:
       label: Gemini 2.5 Pro
       description: Quickly analyze complex, mixed media content.
       preset:
-        endpoint: 'Gemini 2.5 Pro'
+        endpoint: "Gemini 2.5 Pro"
         model: gemini-2.5-pro
     - name: google-gemini-25-flash
       label: Gemini 2.5 Flash
       description: A faster, more lightweight version of Gemini 2.5 Pro.
       preset:
-        endpoint: 'Gemini 2.5 Flash'
+        endpoint: "Gemini 2.5 Flash"
         model: gemini-2.5-flash
     - name: anthropic-claude-sonnet-45
       label: Claude Sonnet 4.5 (Limited)
       description: For extended reasoning, coding, and automation. This model is being evaluated. It can be used a limited number of times.
       preset:
-        endpoint: 'Claude Sonnet 4.5'
+        endpoint: "Claude Sonnet 4.5"
         model: claude-sonnet-4-5
 mcpServers:
   Internet Search (Tavily):
     type: streamable-http
     url: https://mcp.tavily.com/mcp/
     headers:
-      Authorization: 'Bearer ${TAVILY_API_KEY}'
+      Authorization: "Bearer ${TAVILY_API_KEY}"
     startup: true
     chatMenu: false
     requiresOAuth: false
 endpoints:
   azureOpenAI:
     # Endpoint-level configuration
-    titleModel: 'gpt-4o'
+    titleModel: "gpt-4o"
     plugins: false
     assistants: false
     groups:
       # Group-level configuration
-      - group: 'N2A East US'
-        instanceName: 'N2A OpenAI'
-        apiKey: '${AZURE_OPENAI_API_KEY}'
-        baseURL: '${AZURE_OPENAI_BASEURL}'
-        version: '2024-10-21'
+      - group: "N2A East US"
+        instanceName: "N2A OpenAI"
+        apiKey: "${AZURE_OPENAI_API_KEY}"
+        baseURL: "${AZURE_OPENAI_BASEURL}"
+        version: "2024-10-21"
         # Model-level configuration
         models:
           gpt-5:
             deploymentName: gpt-5
-            version: '2024-10-21'
+            version: "2024-10-21"
           gpt-4o:
             deploymentName: gpt-4o
-            version: '2024-10-21'
+            version: "2024-10-21"
           gpt-4o-mini:
             deploymentName: gpt-4o-mini
-            version: '2024-10-21'
+            version: "2024-10-21"
           gpt-41:
             deploymentName: gpt-41
-            version: '2024-10-21'
+            version: "2024-10-21"
           gpt-41-mini:
             deploymentName: gpt-41-mini
-            version: '2024-10-21'
+            version: "2024-10-21"
   custom:
-    - name: 'Gemini 2.5 Pro'
-      apiKey: '${GCP_VERTEXAI_API_KEY}'
-      baseURL: '${GCP_VERTEXAI_BASEURL}/gemini-2.5-pro/v1'
+    - name: "Gemini 2.5 Pro"
+      apiKey: "${GCP_VERTEXAI_API_KEY}"
+      baseURL: "${GCP_VERTEXAI_BASEURL}/gemini-2.5-pro/v1"
       directEndpoint: true
       models:
         default:
           - gemini-2.5-pro
-      titleModel: 'gemini-2.5-pro'
+      titleModel: "gemini-2.5-pro"
       titleConvo: true
-      modelDisplayLabel: 'gemini-2.5-pro'
+      modelDisplayLabel: "gemini-2.5-pro"
       addParams:
         streaming: false
         disableStreaming: true
       dropParams:
         - stream
         - streaming
-    - name: 'Gemini 2.5 Flash'
-      apiKey: '${GCP_VERTEXAI_API_KEY}'
-      baseURL: '${GCP_VERTEXAI_BASEURL}/gemini-2.5-flash/v1'
+    - name: "Gemini 2.5 Flash"
+      apiKey: "${GCP_VERTEXAI_API_KEY}"
+      baseURL: "${GCP_VERTEXAI_BASEURL}/gemini-2.5-flash/v1"
       directEndpoint: true
       models:
         default:
           - gemini-2.5-flash
-      titleModel: 'gemini-2.5-flash'
+      titleModel: "gemini-2.5-flash"
       titleConvo: true
-      modelDisplayLabel: 'gemini-2.5-flash'
+      modelDisplayLabel: "gemini-2.5-flash"
       addParams:
         streaming: false
         disableStreaming: true
       dropParams:
         - stream
         - streaming
-    - name: 'Claude Sonnet 4.5'
-      apiKey: '${GCP_VERTEXAI_API_KEY}'
-      baseURL: '${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1'
+    - name: "Claude Sonnet 4.5"
+      apiKey: "${GCP_VERTEXAI_API_KEY}"
+      baseURL: "${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1"
       directEndpoint: true
       models:
         default:
           - claude-sonnet-4-5
-      titleModel: 'claude-sonnet-4-5'
+      titleModel: "claude-sonnet-4-5"
       titleConvo: true
-      modelDisplayLabel: 'claude-sonnet-4-5'
+      modelDisplayLabel: "claude-sonnet-4-5"
       addParams:
         streaming: false
         disableStreaming: true

--- a/librechat.n2a.yml
+++ b/librechat.n2a.yml
@@ -10,9 +10,9 @@ interface:
 modelSpecs:
   addedEndpoints:
     - azureOpenAI
-    - "Gemini 2.5 Pro"
-    - "Gemini 2.5 Flash"
-    - "Claude Sonnet 4.5"
+    - 'Gemini 2.5 Pro'
+    - 'Gemini 2.5 Flash'
+    - 'Claude Sonnet 4.5'
   list:
     - name: azure-gpt-4o
       label: GPT-4o
@@ -49,99 +49,102 @@ modelSpecs:
       label: Gemini 2.5 Pro
       description: Quickly analyze complex, mixed media content.
       preset:
-        endpoint: "Gemini 2.5 Pro"
+        endpoint: 'Gemini 2.5 Pro'
         model: gemini-2.5-pro
     - name: google-gemini-25-flash
       label: Gemini 2.5 Flash
       description: A faster, more lightweight version of Gemini 2.5 Pro.
       preset:
-        endpoint: "Gemini 2.5 Flash"
+        endpoint: 'Gemini 2.5 Flash'
         model: gemini-2.5-flash
     - name: anthropic-claude-sonnet-45
       label: Claude Sonnet 4.5 (Limited)
       description: For extended reasoning, coding, and automation. This model is being evaluated. It can be used a limited number of times.
       preset:
-        endpoint: "Claude Sonnet 4.5"
+        endpoint: 'Claude Sonnet 4.5'
         model: claude-sonnet-4-5
 mcpServers:
   Internet Search (Tavily):
     type: streamable-http
     url: https://mcp.tavily.com/mcp/
     headers:
-      Authorization: "Bearer ${TAVILY_API_KEY}"
+      Authorization: 'Bearer ${TAVILY_API_KEY}'
+    startup: true
+    chatMenu: false
+    requiresOAuth: false
 endpoints:
   azureOpenAI:
     # Endpoint-level configuration
-    titleModel: "gpt-4o"
+    titleModel: 'gpt-4o'
     plugins: false
     assistants: false
     groups:
-    # Group-level configuration
-    - group: "N2A East US"
-      instanceName: "N2A OpenAI"
-      apiKey: "${AZURE_OPENAI_API_KEY}"
-      baseURL: "${AZURE_OPENAI_BASEURL}"
-      version: "2024-10-21"
-      # Model-level configuration
-      models:
-        gpt-5:
-          deploymentName: gpt-5
-          version: "2024-10-21"
-        gpt-4o:
-          deploymentName: gpt-4o
-          version: "2024-10-21"
-        gpt-4o-mini:
-          deploymentName: gpt-4o-mini
-          version: "2024-10-21"
-        gpt-41:
-          deploymentName: gpt-41
-          version: "2024-10-21"
-        gpt-41-mini:
-          deploymentName: gpt-41-mini
-          version: "2024-10-21"
+      # Group-level configuration
+      - group: 'N2A East US'
+        instanceName: 'N2A OpenAI'
+        apiKey: '${AZURE_OPENAI_API_KEY}'
+        baseURL: '${AZURE_OPENAI_BASEURL}'
+        version: '2024-10-21'
+        # Model-level configuration
+        models:
+          gpt-5:
+            deploymentName: gpt-5
+            version: '2024-10-21'
+          gpt-4o:
+            deploymentName: gpt-4o
+            version: '2024-10-21'
+          gpt-4o-mini:
+            deploymentName: gpt-4o-mini
+            version: '2024-10-21'
+          gpt-41:
+            deploymentName: gpt-41
+            version: '2024-10-21'
+          gpt-41-mini:
+            deploymentName: gpt-41-mini
+            version: '2024-10-21'
   custom:
-    - name: "Gemini 2.5 Pro"
-      apiKey: "${GCP_VERTEXAI_API_KEY}"
-      baseURL: "${GCP_VERTEXAI_BASEURL}/gemini-2.5-pro/v1"
+    - name: 'Gemini 2.5 Pro'
+      apiKey: '${GCP_VERTEXAI_API_KEY}'
+      baseURL: '${GCP_VERTEXAI_BASEURL}/gemini-2.5-pro/v1'
       directEndpoint: true
       models:
         default:
           - gemini-2.5-pro
-      titleModel: "gemini-2.5-pro"
+      titleModel: 'gemini-2.5-pro'
       titleConvo: true
-      modelDisplayLabel: "gemini-2.5-pro"
+      modelDisplayLabel: 'gemini-2.5-pro'
       addParams:
         streaming: false
         disableStreaming: true
       dropParams:
         - stream
         - streaming
-    - name: "Gemini 2.5 Flash"
-      apiKey: "${GCP_VERTEXAI_API_KEY}"
-      baseURL: "${GCP_VERTEXAI_BASEURL}/gemini-2.5-flash/v1"
+    - name: 'Gemini 2.5 Flash'
+      apiKey: '${GCP_VERTEXAI_API_KEY}'
+      baseURL: '${GCP_VERTEXAI_BASEURL}/gemini-2.5-flash/v1'
       directEndpoint: true
       models:
         default:
           - gemini-2.5-flash
-      titleModel: "gemini-2.5-flash"
+      titleModel: 'gemini-2.5-flash'
       titleConvo: true
-      modelDisplayLabel: "gemini-2.5-flash"
+      modelDisplayLabel: 'gemini-2.5-flash'
       addParams:
         streaming: false
         disableStreaming: true
       dropParams:
         - stream
         - streaming
-    - name: "Claude Sonnet 4.5"
-      apiKey: "${GCP_VERTEXAI_API_KEY}"
-      baseURL: "${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1"
+    - name: 'Claude Sonnet 4.5'
+      apiKey: '${GCP_VERTEXAI_API_KEY}'
+      baseURL: '${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1'
       directEndpoint: true
       models:
         default:
           - claude-sonnet-4-5
-      titleModel: "claude-sonnet-4-5"
+      titleModel: 'claude-sonnet-4-5'
       titleConvo: true
-      modelDisplayLabel: "claude-sonnet-4-5"
+      modelDisplayLabel: 'claude-sonnet-4-5'
       addParams:
         streaming: false
         disableStreaming: true

--- a/librechat.prod.yml
+++ b/librechat.prod.yml
@@ -8,9 +8,9 @@ interface:
 modelSpecs:
   addedEndpoints:
     - azureOpenAI
-    - 'Gemini 2.5 Pro'
-    - 'Gemini 2.5 Flash'
-    - 'Claude Sonnet 4.5'
+    - "Gemini 2.5 Pro"
+    - "Gemini 2.5 Flash"
+    - "Claude Sonnet 4.5"
   list:
     - name: azure-gpt-4o
       label: GPT-4o
@@ -47,102 +47,102 @@ modelSpecs:
       label: Gemini 2.5 Pro
       description: Quickly analyze complex, mixed media content.
       preset:
-        endpoint: 'Gemini 2.5 Pro'
+        endpoint: "Gemini 2.5 Pro"
         model: gemini-2.5-pro
     - name: google-gemini-25-flash
       label: Gemini 2.5 Flash
       description: A faster, more lightweight version of Gemini 2.5 Pro.
       preset:
-        endpoint: 'Gemini 2.5 Flash'
+        endpoint: "Gemini 2.5 Flash"
         model: gemini-2.5-flash
     - name: anthropic-claude-sonnet-45
       label: Claude Sonnet 4.5 (Limited)
       description: For extended reasoning, coding, and automation. This model is being evaluated. It can be used a limited number of times.
       preset:
-        endpoint: 'Claude Sonnet 4.5'
+        endpoint: "Claude Sonnet 4.5"
         model: claude-sonnet-4-5
 mcpServers:
   Internet Search (Tavily):
     type: streamable-http
     url: https://mcp.tavily.com/mcp/
     headers:
-      Authorization: 'Bearer ${TAVILY_API_KEY}'
+      Authorization: "Bearer ${TAVILY_API_KEY}"
     startup: true
     chatMenu: false
     requiresOAuth: false
 endpoints:
   azureOpenAI:
     # Endpoint-level configuration
-    titleModel: 'gpt-4o'
+    titleModel: "gpt-4o"
     plugins: false
     assistants: false
     groups:
       # Group-level configuration
-      - group: 'Prod East US'
-        instanceName: 'Prod OpenAI'
-        apiKey: '${AZURE_OPENAI_API_KEY}'
-        baseURL: '${AZURE_OPENAI_BASEURL}'
-        version: '2024-10-21'
+      - group: "Prod East US"
+        instanceName: "Prod OpenAI"
+        apiKey: "${AZURE_OPENAI_API_KEY}"
+        baseURL: "${AZURE_OPENAI_BASEURL}"
+        version: "2024-10-21"
         # Model-level configuration
         models:
           gpt-5:
             deploymentName: gpt-5
-            version: '2024-10-21'
+            version: "2024-10-21"
           gpt-4o:
             deploymentName: gpt-4o
-            version: '2024-10-21'
+            version: "2024-10-21"
           gpt-4o-mini:
             deploymentName: gpt-4o-mini
-            version: '2024-10-21'
+            version: "2024-10-21"
           gpt-41:
             deploymentName: gpt-41
-            version: '2024-10-21'
+            version: "2024-10-21"
           gpt-41-mini:
             deploymentName: gpt-41-mini
-            version: '2024-10-21'
+            version: "2024-10-21"
   custom:
-    - name: 'Gemini 2.5 Pro'
-      apiKey: '${GCP_VERTEXAI_API_KEY}'
-      baseURL: '${GCP_VERTEXAI_BASEURL}/gemini-2.5-pro/v1'
+    - name: "Gemini 2.5 Pro"
+      apiKey: "${GCP_VERTEXAI_API_KEY}"
+      baseURL: "${GCP_VERTEXAI_BASEURL}/gemini-2.5-pro/v1"
       directEndpoint: true
       models:
         default:
           - gemini-2.5-pro
-      titleModel: 'gemini-2.5-pro'
+      titleModel: "gemini-2.5-pro"
       titleConvo: true
-      modelDisplayLabel: 'gemini-2.5-pro'
+      modelDisplayLabel: "gemini-2.5-pro"
       addParams:
         streaming: false
         disableStreaming: true
       dropParams:
         - stream
         - streaming
-    - name: 'Gemini 2.5 Flash'
-      apiKey: '${GCP_VERTEXAI_API_KEY}'
-      baseURL: '${GCP_VERTEXAI_BASEURL}/gemini-2.5-flash/v1'
+    - name: "Gemini 2.5 Flash"
+      apiKey: "${GCP_VERTEXAI_API_KEY}"
+      baseURL: "${GCP_VERTEXAI_BASEURL}/gemini-2.5-flash/v1"
       directEndpoint: true
       models:
         default:
           - gemini-2.5-flash
-      titleModel: 'gemini-2.5-flash'
+      titleModel: "gemini-2.5-flash"
       titleConvo: true
-      modelDisplayLabel: 'gemini-2.5-flash'
+      modelDisplayLabel: "gemini-2.5-flash"
       addParams:
         streaming: false
         disableStreaming: true
       dropParams:
         - stream
         - streaming
-    - name: 'Claude Sonnet 4.5'
-      apiKey: '${GCP_VERTEXAI_API_KEY}'
-      baseURL: '${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1'
+    - name: "Claude Sonnet 4.5"
+      apiKey: "${GCP_VERTEXAI_API_KEY}"
+      baseURL: "${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1"
       directEndpoint: true
       models:
         default:
           - claude-sonnet-4-5
-      titleModel: 'claude-sonnet-4-5'
+      titleModel: "claude-sonnet-4-5"
       titleConvo: true
-      modelDisplayLabel: 'claude-sonnet-4-5'
+      modelDisplayLabel: "claude-sonnet-4-5"
       addParams:
         streaming: false
         disableStreaming: true

--- a/librechat.prod.yml
+++ b/librechat.prod.yml
@@ -8,9 +8,9 @@ interface:
 modelSpecs:
   addedEndpoints:
     - azureOpenAI
-    - "Gemini 2.5 Pro"
-    - "Gemini 2.5 Flash"
-    - "Claude Sonnet 4.5"
+    - 'Gemini 2.5 Pro'
+    - 'Gemini 2.5 Flash'
+    - 'Claude Sonnet 4.5'
   list:
     - name: azure-gpt-4o
       label: GPT-4o
@@ -47,99 +47,102 @@ modelSpecs:
       label: Gemini 2.5 Pro
       description: Quickly analyze complex, mixed media content.
       preset:
-        endpoint: "Gemini 2.5 Pro"
+        endpoint: 'Gemini 2.5 Pro'
         model: gemini-2.5-pro
     - name: google-gemini-25-flash
       label: Gemini 2.5 Flash
       description: A faster, more lightweight version of Gemini 2.5 Pro.
       preset:
-        endpoint: "Gemini 2.5 Flash"
+        endpoint: 'Gemini 2.5 Flash'
         model: gemini-2.5-flash
     - name: anthropic-claude-sonnet-45
       label: Claude Sonnet 4.5 (Limited)
       description: For extended reasoning, coding, and automation. This model is being evaluated. It can be used a limited number of times.
       preset:
-        endpoint: "Claude Sonnet 4.5"
+        endpoint: 'Claude Sonnet 4.5'
         model: claude-sonnet-4-5
 mcpServers:
   Internet Search (Tavily):
     type: streamable-http
     url: https://mcp.tavily.com/mcp/
     headers:
-      Authorization: "Bearer ${TAVILY_API_KEY}"
+      Authorization: 'Bearer ${TAVILY_API_KEY}'
+    startup: true
+    chatMenu: false
+    requiresOAuth: false
 endpoints:
   azureOpenAI:
     # Endpoint-level configuration
-    titleModel: "gpt-4o"
+    titleModel: 'gpt-4o'
     plugins: false
     assistants: false
     groups:
-    # Group-level configuration
-    - group: "Prod East US"
-      instanceName: "Prod OpenAI"
-      apiKey: "${AZURE_OPENAI_API_KEY}"
-      baseURL: "${AZURE_OPENAI_BASEURL}"
-      version: "2024-10-21"
-      # Model-level configuration
-      models:
-        gpt-5:
-          deploymentName: gpt-5
-          version: "2024-10-21"
-        gpt-4o:
-          deploymentName: gpt-4o
-          version: "2024-10-21"
-        gpt-4o-mini:
-          deploymentName: gpt-4o-mini
-          version: "2024-10-21"
-        gpt-41:
-          deploymentName: gpt-41
-          version: "2024-10-21"
-        gpt-41-mini:
-          deploymentName: gpt-41-mini
-          version: "2024-10-21"
+      # Group-level configuration
+      - group: 'Prod East US'
+        instanceName: 'Prod OpenAI'
+        apiKey: '${AZURE_OPENAI_API_KEY}'
+        baseURL: '${AZURE_OPENAI_BASEURL}'
+        version: '2024-10-21'
+        # Model-level configuration
+        models:
+          gpt-5:
+            deploymentName: gpt-5
+            version: '2024-10-21'
+          gpt-4o:
+            deploymentName: gpt-4o
+            version: '2024-10-21'
+          gpt-4o-mini:
+            deploymentName: gpt-4o-mini
+            version: '2024-10-21'
+          gpt-41:
+            deploymentName: gpt-41
+            version: '2024-10-21'
+          gpt-41-mini:
+            deploymentName: gpt-41-mini
+            version: '2024-10-21'
   custom:
-    - name: "Gemini 2.5 Pro"
-      apiKey: "${GCP_VERTEXAI_API_KEY}"
-      baseURL: "${GCP_VERTEXAI_BASEURL}/gemini-2.5-pro/v1"
+    - name: 'Gemini 2.5 Pro'
+      apiKey: '${GCP_VERTEXAI_API_KEY}'
+      baseURL: '${GCP_VERTEXAI_BASEURL}/gemini-2.5-pro/v1'
       directEndpoint: true
       models:
         default:
           - gemini-2.5-pro
-      titleModel: "gemini-2.5-pro"
+      titleModel: 'gemini-2.5-pro'
       titleConvo: true
-      modelDisplayLabel: "gemini-2.5-pro"
+      modelDisplayLabel: 'gemini-2.5-pro'
       addParams:
         streaming: false
         disableStreaming: true
       dropParams:
         - stream
         - streaming
-    - name: "Gemini 2.5 Flash"
-      apiKey: "${GCP_VERTEXAI_API_KEY}"
-      baseURL: "${GCP_VERTEXAI_BASEURL}/gemini-2.5-flash/v1"
+    - name: 'Gemini 2.5 Flash'
+      apiKey: '${GCP_VERTEXAI_API_KEY}'
+      baseURL: '${GCP_VERTEXAI_BASEURL}/gemini-2.5-flash/v1'
       directEndpoint: true
       models:
         default:
           - gemini-2.5-flash
-      titleModel: "gemini-2.5-flash"
+      titleModel: 'gemini-2.5-flash'
       titleConvo: true
-      modelDisplayLabel: "gemini-2.5-flash"
+      modelDisplayLabel: 'gemini-2.5-flash'
       addParams:
         streaming: false
         disableStreaming: true
       dropParams:
         - stream
         - streaming
-    - name: "Claude Sonnet 4.5"
-      apiKey: "${GCP_VERTEXAI_API_KEY}"
-      baseURL: "${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1"
+    - name: 'Claude Sonnet 4.5'
+      apiKey: '${GCP_VERTEXAI_API_KEY}'
+      baseURL: '${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1'
       directEndpoint: true
       models:
         default:
           - claude-sonnet-4-5
-      titleModel: "claude-sonnet-4-5"
+      titleModel: 'claude-sonnet-4-5'
       titleConvo: true
-      modelDisplayLabel: "claude-sonnet-4-5"
+      modelDisplayLabel: 'claude-sonnet-4-5'
       addParams:
         streaming: false
         disableStreaming: true


### PR DESCRIPTION
I was originally planning on having these changes in two different pull requests, but it looks like the search results changes were still in the branch that I started to work on the Tavily always on search functionality. Rather than trying to figure out how to safely remove that functionality for two different PR's I'm just putting them in this single one.

This change makes it so that if a user expands the search section for A Tavily search, the content from the results is rendered in markdown, allowing the user to click on links to the websites the information was source from.

This change also include the functionality to have Tavily constantly enabled. This is done by having Tavily enabled by default and then hiding it as an option for MCP server selection. So even though it might look as though the option to use Tavily is gone, it's actually on all the time in the background now.

I have tested these changes, but I'd request someone else on the team review and test them as well.