### PR TITLE
feat: sync payx custom features from release/v0.8.0.6-payx to main

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh 
-#set -e
-#. "$(dirname -- "$0")/_/husky.sh"
-#[ -n "$CI" ] && exit 0
-#npx lint-staged --config ./.husky/lint-staged.config.js
+set -e
+. "$(dirname -- "$0")/_/husky.sh"
+[ -n "$CI" ] && exit 0
+npx lint-staged --config ./.husky/lint-staged.config.js

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -895,6 +895,8 @@ class BaseClient {
 
     _messages = await this.addPreviousAttachments(_messages);
 
+    _messages = this.filterCrossProviderToolCalls(_messages);
+
     if (!this.shouldSummarize) {
       return _messages;
     }
@@ -918,6 +920,73 @@ class BaseClient {
     }
 
     return _messages;
+  }
+
+  /**
+   * Filters out tool-related content from messages created by a different provider.
+   * This prevents errors when switching between providers mid-conversation.
+   *
+   * @param {TMessage[]} messages - Array of messages to filter
+   * @returns {TMessage[]} Messages with tool content filtered based on endpoint
+   */
+  filterCrossProviderToolCalls(messages) {
+    const currentEndpoint = this.options?.endpoint;
+
+    if (!currentEndpoint || !messages || messages.length === 0) {
+      return messages;
+    }
+
+    return messages
+      .map((message) => {
+        if (message.endpoint === currentEndpoint || !message.endpoint) {
+          return message;
+        }
+
+        if (!Array.isArray(message.content)) {
+          return message;
+        }
+
+        // Filter out tool_call types from different endpoint
+        const filteredContent = message.content.filter((part) => {
+          if (part.type === ContentTypes.TOOL_CALL) {
+            return false;
+          }
+          // Filter text parts that announce tool calls
+          if (part.type === ContentTypes.TEXT && part.tool_call_ids?.length) {
+            return false;
+          }
+          return true;
+        });
+
+        if (filteredContent.length === 0) {
+          logger.debug(
+            '[BaseClient] Excluding message with only tool content from different provider:',
+            {
+              messageId: message.messageId,
+              fromEndpoint: message.endpoint,
+              toEndpoint: currentEndpoint,
+            },
+          );
+          return null;
+        }
+
+        if (filteredContent.length !== message.content.length) {
+          logger.debug('[BaseClient] Filtered tool calls from message:', {
+            messageId: message.messageId,
+            fromEndpoint: message.endpoint,
+            toEndpoint: currentEndpoint,
+            removedCount: message.content.length - filteredContent.length,
+          });
+
+          return {
+            ...message,
+            content: filteredContent,
+          };
+        }
+
+        return message;
+      })
+      .filter((message) => message !== null);
   }
 
   /**

--- a/api/server/services/Config/mcp.js
+++ b/api/server/services/Config/mcp.js
@@ -1,5 +1,6 @@
 const { logger } = require('@librechat/data-schemas');
 const { CacheKeys, Constants } = require('librechat-data-provider');
+const { sanitizeSchemaMetadata } = require('@librechat/api');
 const { getCachedTools, setCachedTools } = require('./getCachedTools');
 const { getLogStores } = require('~/cache');
 
@@ -28,7 +29,7 @@ async function updateMCPServerTools({ userId, serverName, tools }) {
         ['function']: {
           name,
           description: tool.description,
-          parameters: tool.inputSchema,
+          parameters: sanitizeSchemaMetadata(tool.inputSchema),
         },
       };
     }

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -307,7 +307,13 @@ async function createMCPTool({
 function createToolInstance({ res, toolName, serverName, toolDefinition, provider: _provider }) {
   /** @type {LCTool} */
   const { description, parameters } = toolDefinition;
-  const isGoogle = _provider === Providers.VERTEXAI || _provider === Providers.GOOGLE;
+  const providerLower = _provider?.toLowerCase?.() ?? '';
+  // Check for Google providers (native or custom Gemini endpoints)
+  const isGoogle =
+    _provider === Providers.VERTEXAI ||
+    _provider === Providers.GOOGLE ||
+    providerLower.includes('gemini') ||
+    providerLower.includes('google');
   let schema = convertWithResolvedRefs(parameters, {
     allowEmptyObject: !isGoogle,
     transformOneOfAnyOf: true,
@@ -384,7 +390,12 @@ function createToolInstance({ res, toolName, serverName, toolDefinition, provide
       if (isAssistantsEndpoint(provider) && Array.isArray(result)) {
         return result[0];
       }
-      if (isGoogle && Array.isArray(result[0]) && result[0][0]?.type === ContentTypes.TEXT) {
+      // Check if this is a Google-like provider (native Google or custom Gemini endpoint)
+      // Custom Gemini endpoints use OpenAI-compatible format but need text extraction
+      // to avoid sending array content that causes "Proto field is not repeating" errors
+      const isGoogleLike =
+        isGoogle || (provider && (provider.includes('gemini') || provider.includes('google')));
+      if (isGoogleLike && Array.isArray(result[0]) && result[0][0]?.type === ContentTypes.TEXT) {
         return [result[0][0].text, result[1]];
       }
       return result;

--- a/client/src/common/menus.ts
+++ b/client/src/common/menus.ts
@@ -7,6 +7,7 @@ export type RenderProp<
 export interface MenuItemProps {
   id?: string;
   label?: string;
+  description?: string;
   onClick?: (e: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) => void;
   icon?: React.ReactNode;
   kbd?: string;

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -129,6 +129,7 @@ const AttachFileMenu = ({
       } else {
         items.push({
           label: localize('com_ui_upload_image_input'),
+          description: localize('com_ui_upload_image_input_description'),
           onClick: () => {
             setToolResource(undefined);
             onAction('image');
@@ -140,6 +141,7 @@ const AttachFileMenu = ({
       if (capabilities.contextEnabled) {
         items.push({
           label: localize('com_ui_upload_ocr_text'),
+          description: localize('com_ui_upload_ocr_text_description'),
           onClick: () => {
             setToolResource(EToolResources.context);
             onAction();
@@ -151,6 +153,7 @@ const AttachFileMenu = ({
       if (capabilities.fileSearchEnabled && fileSearchAllowedByAgent) {
         items.push({
           label: localize('com_ui_upload_file_search'),
+          description: localize('com_ui_upload_file_search_description'),
           onClick: () => {
             setToolResource(EToolResources.file_search);
             setEphemeralAgent((prev) => ({
@@ -166,6 +169,7 @@ const AttachFileMenu = ({
       if (capabilities.codeEnabled && codeAllowedByAgent) {
         items.push({
           label: localize('com_ui_upload_code_files'),
+          description: localize('com_ui_upload_code_files_description'),
           onClick: () => {
             setToolResource(EToolResources.execute_code);
             setEphemeralAgent((prev) => ({

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -11,7 +11,7 @@ import {
 import { MarketplaceProvider } from '~/components/Agents/MarketplaceContext';
 import AgentMarketplace from '~/components/Agents/Marketplace';
 import { OAuthSuccess, OAuthError } from '~/components/OAuth';
-import { AuthContextProvider } from '~/hooks/AuthContext';
+import { AuthContextProvider, PendoInitializer } from '~/hooks';
 import RouteErrorBoundary from './RouteErrorBoundary';
 import StartupLayout from './Layouts/Startup';
 import LoginLayout from './Layouts/Login';
@@ -23,8 +23,10 @@ import Root from './Root';
 
 const AuthLayout = () => (
   <AuthContextProvider>
-    <Outlet />
-    <ApiErrorWatcher />
+    <PendoInitializer>
+      <Outlet />
+      <ApiErrorWatcher />
+    </PendoInitializer>
   </AuthContextProvider>
 );
 

--- a/packages/api/src/utils/index.ts
+++ b/packages/api/src/utils/index.ts
@@ -15,6 +15,7 @@ export * from './math';
 export * from './openid';
 export * from './promise';
 export * from './sanitizeTitle';
+export * from './schema';
 export * from './tempChatRetention';
 export * from './text';
 export { default as Tokenizer, countTokens } from './tokenizer';

--- a/packages/api/src/utils/schema.ts
+++ b/packages/api/src/utils/schema.ts
@@ -1,0 +1,42 @@
+/**
+ * Recursively removes metadata fields (like `$schema`) from JSON Schema objects.
+ * This is necessary because some providers (e.g., Google Gemini) reject schemas
+ * that contain these optional metadata fields.
+ *
+ * @param value - The value to sanitize (can be any JSON Schema value)
+ * @returns The sanitized value with metadata fields removed
+ */
+export function sanitizeSchemaMetadata<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeSchemaMetadata) as T;
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.keys(value).reduce((acc, key) => {
+      if (key === '$schema') {
+        return acc;
+      }
+      (acc as Record<string, unknown>)[key] = sanitizeSchemaMetadata(
+        (value as Record<string, unknown>)[key],
+      );
+      return acc;
+    }, {} as T);
+  }
+
+  return value;
+}
+
+/**
+ * Sanitizes a JSON Schema by removing provider-incompatible metadata fields.
+ * Use this function when preparing tool schemas for API calls to providers
+ * like Google Gemini that reject unknown schema properties.
+ *
+ * @param schema - The JSON Schema to sanitize
+ * @returns The sanitized JSON Schema (same type as input)
+ */
+export function sanitizeToolSchema<T>(schema: T): T {
+  if (schema == null) {
+    return schema;
+  }
+  return sanitizeSchemaMetadata(schema) as T;
+}

--- a/packages/client/src/common/menus.ts
+++ b/packages/client/src/common/menus.ts
@@ -8,6 +8,7 @@ export type RenderProp<
 export interface MenuItemProps {
   id?: string;
   label?: string;
+  description?: string;
   onClick?: (e: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) => void;
   icon?: React.ReactNode;
   kbd?: string;
@@ -21,4 +22,5 @@ export interface MenuItemProps {
     | RenderProp<React.HTMLAttributes<any> & { ref?: React.Ref<any> | undefined }>
     | React.ReactElement<any, string | React.JSXElementConstructor<any>>
     | undefined;
+  subItems?: MenuItemProps[];
 }

--- a/packages/client/src/components/DropdownPopup.tsx
+++ b/packages/client/src/components/DropdownPopup.tsx
@@ -75,6 +75,21 @@ const Menu: React.FC<MenuProps> = ({
 }) => {
   const menuStore = Ariakit.useMenuStore();
   const menu = Ariakit.useMenuContext();
+  const renderItemBody = (item: t.MenuItemProps) => (
+    <div className="flex flex-1 items-start gap-3">
+      {item.icon != null && (
+        <span className={cn('mt-0.5 size-4 flex-shrink-0', iconClassName)} aria-hidden="true">
+          {item.icon}
+        </span>
+      )}
+      <div className="flex flex-1 flex-col text-left">
+        <span className="text-sm font-medium text-text-primary">{item.label}</span>
+        {item.description && (
+          <span className="text-xs leading-tight text-text-tertiary">{item.description}</span>
+        )}
+      </div>
+    </div>
+  );
   return (
     <Ariakit.Menu
       id={menuId}
@@ -103,7 +118,7 @@ const Menu: React.FC<MenuProps> = ({
               >
                 <Ariakit.MenuButton
                   className={cn(
-                    'group flex w-full cursor-pointer items-center justify-between gap-2 rounded-lg px-3 py-3.5 text-sm text-text-primary outline-none transition-colors duration-200 hover:bg-surface-hover focus:bg-surface-hover md:px-2.5 md:py-2',
+                    'group flex w-full cursor-pointer items-start justify-between gap-2 rounded-lg px-3 py-3.5 text-sm text-text-primary outline-none transition-colors duration-200 hover:bg-surface-hover focus:bg-surface-hover md:px-2.5 md:py-2',
                     itemClassName,
                   )}
                   disabled={item.disabled}
@@ -112,15 +127,8 @@ const Menu: React.FC<MenuProps> = ({
                   ref={item.ref}
                   // hideOnClick={item.hideOnClick}
                 >
-                  <span className="flex items-center gap-2">
-                    {item.icon != null && (
-                      <span className={cn('mr-2 size-4', iconClassName)} aria-hidden="true">
-                        {item.icon}
-                      </span>
-                    )}
-                    {item.label}
-                  </span>
-                  <Ariakit.MenuButtonArrow className="stroke-1 text-base opacity-75" />
+                  {renderItemBody(item)}
+                  <Ariakit.MenuButtonArrow className="self-center stroke-1 text-base opacity-75" />
                 </Ariakit.MenuButton>
                 <Menu
                   items={subItems}
@@ -138,7 +146,7 @@ const Menu: React.FC<MenuProps> = ({
               key={`${keyPrefix ?? ''}${index}-${item.id ?? ''}`}
               id={item.id}
               className={cn(
-                'group flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-3.5 text-sm text-text-primary outline-none transition-colors duration-200 hover:bg-surface-hover focus:bg-surface-hover md:px-2.5 md:py-2',
+                'group flex w-full cursor-pointer items-start gap-2 rounded-lg px-3 py-3.5 text-sm text-text-primary outline-none transition-colors duration-200 hover:bg-surface-hover focus:bg-surface-hover md:px-2.5 md:py-2',
                 itemClassName,
               )}
               disabled={item.disabled}
@@ -156,12 +164,7 @@ const Menu: React.FC<MenuProps> = ({
                 menu?.hide();
               }}
             >
-              {item.icon != null && (
-                <span className={cn('mr-2 size-4', iconClassName)} aria-hidden="true">
-                  {item.icon}
-                </span>
-              )}
-              {item.label}
+              {renderItemBody(item)}
               {item.kbd != null && (
                 <kbd className="ml-auto hidden font-sans text-xs text-black/50 group-hover:inline group-focus:inline dark:text-white/50">
                   ⌘{item.kbd}


### PR DESCRIPTION
Port custom Paychex features from the v0.8.0.x release branch to main (v0.8.1).

## Features Ported

### 1. Tool Call Sanitization
- Added filterCrossProviderToolCalls() to BaseClient.js
- Filters orphaned tool call refs when switching providers mid-conversation
- Prevents 'Proto field is not repeating' errors

### 2. Gemini Compatibility Fixes
- Extended isGoogle check in MCP.js for custom Gemini endpoints
- Added sanitizeSchemaMetadata() to remove $schema fields from tool params
- Google's OpenAI-compatible API rejects tool parameters containing $schema

### 3. Model Selection Persistence
- Preserves user's last model selection for new chats
- Only applies default preset for brand new users without stored selection

### 4. UI Menu Descriptions
- Added description property to MenuItemProps
- Updated DropdownPopup to render item descriptions
- Added descriptions to file upload menu items