### PR TITLE
fix: use && instead of ; in Dockerfile to fail on frontend build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ COPY --chown=node:node . .
 
 RUN \
     # React client build
-    NODE_OPTIONS="--max-old-space-size=2048" npm run frontend; \
-    npm prune --production; \
+    NODE_OPTIONS="--max-old-space-size=2048" npm run frontend && \
+    npm prune --production && \
     npm cache clean --force
 
 # Node API setup


### PR DESCRIPTION
The Dockerfile was using `;` to chain commands in the RUN statement, which meant that if `npm run frontend` failed, the Docker build would still succeed (because the exit code would be from the last command, `npm cache clean`).

This caused N1 to deploy a broken image where `/app/client/dist/index.html` was missing because the frontend build had failed silently.

This fix changes `;` to `&&` so that build failures properly fail the Docker build.

**Root cause of the frontend failure:**
The vite build was failing with: `"AudioPaths" is not exported by "../packages/client/dist/index.es.js"`

This PR ensures such failures are caught at build time.