### PR TITLE
chore: retarget n1 and n2a workflows to 002 apps

### DIFF
--- a/.github/workflows/n1-build-and-push.yml
+++ b/.github/workflows/n1-build-and-push.yml
@@ -7,6 +7,9 @@ env:
     ACR_PASS: ${{ secrets.REGISTRY_PASSWORD_PROD }}
 
 on:
+  push:
+    branches:
+      - release/*
   workflow_dispatch:
       inputs:
           build_rag_api_image:
@@ -27,7 +30,7 @@ jobs:
             - uses: actions/checkout@v3
               with:
                 fetch-depth: 0 # fetch all branches and tags
-                ref: ${{ inputs.branch }}
+                ref: ${{ inputs.branch || github.ref }}
 
             - name: Get commit SHA
               id: commit_sha
@@ -58,7 +61,7 @@ jobs:
                 docker push ${{ env.ACR_HOST }}/paychex/librechat:n1.latest
 
             - name: Trigger rag_api Workflow
-              if: ${{inputs.build_rag_api_image}}
+              if: ${{ github.event.inputs.build_rag_api_image != 'false' }}
               uses: BeewiseTechnologiesLTD/remote-workflow-trigger@v1
               with:
                 target_repo: 'paychex/rag_api'

--- a/.github/workflows/n1-build-and-push.yml
+++ b/.github/workflows/n1-build-and-push.yml
@@ -7,9 +7,6 @@ env:
     ACR_PASS: ${{ secrets.REGISTRY_PASSWORD_PROD }}
 
 on:
-  push:
-    branches:
-      - release/*
   workflow_dispatch:
       inputs:
           build_rag_api_image:
@@ -30,7 +27,7 @@ jobs:
             - uses: actions/checkout@v3
               with:
                 fetch-depth: 0 # fetch all branches and tags
-                ref: ${{ inputs.branch || github.ref }}
+                ref: ${{ inputs.branch }}
 
             - name: Get commit SHA
               id: commit_sha
@@ -69,11 +66,6 @@ jobs:
                 github_token: ${{ secrets.CROSS_REPO_PAT }}
                 ref: 'main'
 
-            - name: Update librechat image in YAML
-              uses: mikefarah/yq@master
-              with:
-                cmd: yq -i '.properties.template.containers[] |= select(.name == "conpaichat").image = "${{ env.ACR_HOST }}/paychex/librechat:n1.${{ env.COMMIT_SHA }}"' az_container_app_definitions/n1_container_app_definition.yml
-
             - name: Azure CLI script
               uses: azure/cli@v2
               with:
@@ -81,6 +73,13 @@ jobs:
                     az login --service-principal -u ${{secrets.ARC_RUNNER_SP_CLIENT_ID_NONPROD}} -p ${{secrets.ARC_RUNNER_SP_CLIENT_SECRET_NONPROD}} --tenant ${{secrets.AZURE_TENANT_ID}}
                     az account set --subscription "${{ secrets.AZURE_NONPROD_SUBSCRIPTION_ID }}"
                     az containerapp update \
-                      --name conpaichateastusn1001 \
-                      --resource-group rg-playai-eastus-n1-001 \
-                      --yaml $GITHUB_WORKSPACE/az_container_app_definitions/n1_container_app_definition.yml
+                      --name conplayaieastusn1002 \
+                      --resource-group rg-playai-eastus-n1-002 \
+                      --container-name conplayai \
+                      --image ${{ env.ACR_HOST }}/paychex/librechat:n1.${{ env.COMMIT_SHA }}
+                    az containerapp update \
+                      --name conplayaieastusn1002 \
+                      --resource-group rg-playai-eastus-n1-002 \
+                      --container-name conplayairag \
+                      --image ${{ env.ACR_HOST }}/paychex/rag_api:n1.latest \
+                      --output none

--- a/.github/workflows/n2a-build-and-push.yml
+++ b/.github/workflows/n2a-build-and-push.yml
@@ -7,10 +7,10 @@ env:
     ACR_PASS: ${{ secrets.REGISTRY_PASSWORD_PROD }}
 
 on:
-  # Automated deploy on push to main branch
+  # Automated deploy on push to develop branch
   push:
     branches:
-      - main
+      - develop
   # Manual trigger
   workflow_dispatch:
       inputs:

--- a/.github/workflows/n2a-build-and-push.yml
+++ b/.github/workflows/n2a-build-and-push.yml
@@ -7,10 +7,10 @@ env:
     ACR_PASS: ${{ secrets.REGISTRY_PASSWORD_PROD }}
 
 on:
-  # Automated deploy on push to develop branch
+  # Automated deploy on push to main branch
   push:
     branches:
-      - develop
+      - main
   # Manual trigger
   workflow_dispatch:
       inputs:
@@ -106,18 +106,20 @@ jobs:
                 fetch-depth: 0
                 ref: ${{ github.event.inputs.branch || github.ref }}
 
-            - name: Update librechat image in YAML
-              uses: mikefarah/yq@master
-              with:
-                cmd: yq -i '.properties.template.containers[] |= select(.name == "conpaichat").image = "${{ env.ACR_HOST }}/paychex/librechat:n2a.${{ needs.build.outputs.commit_sha }}"' az_container_app_definitions/n2a_container_app_definition.yml
-                    
             - name: Azure CLI script
               uses: azure/cli@v2
               with:
                   inlineScript: |
                     az login --service-principal -u ${{secrets.ARC_RUNNER_SP_CLIENT_ID_NONPROD}} -p ${{secrets.ARC_RUNNER_SP_CLIENT_SECRET_NONPROD}} --tenant ${{secrets.AZURE_TENANT_ID}}
                     az account set --subscription "${{ secrets.AZURE_NONPROD_SUBSCRIPTION_ID }}"
-                    az containerapp create \
-                      --name conpaichateastusn2a001 \
-                      --resource-group rg-playai-eastus-n2a-001 \
-                      --yaml $GITHUB_WORKSPACE/az_container_app_definitions/n2a_container_app_definition.yml
+                    az containerapp update \
+                      --name conpaichateastusn2a002 \
+                      --resource-group rg-playai-eastus-n2a-002 \
+                      --container-name conpaichat \
+                      --image ${{ env.ACR_HOST }}/paychex/librechat:n2a.${{ needs.build.outputs.commit_sha }}
+                    az containerapp update \
+                      --name conpaichateastusn2a002 \
+                      --resource-group rg-playai-eastus-n2a-002 \
+                      --container-name conpairag \
+                      --image ${{ env.ACR_HOST }}/paychex/rag_api:n2a.latest \
+                      --output none


### PR DESCRIPTION
## Summary
- retarget legacy N1 deploy workflow to `conplayaieastusn1002` in `rg-playai-eastus-n1-002`
- retarget legacy N2A deploy workflow to `conpaichateastusn2a002` in `rg-playai-eastus-n2a-002`
- switch both workflows to direct `az containerapp update` image updates for app + rag containers

## Validation
- YAML parse check for both updated workflow files
