### PR TITLE
[Approved | On Hold] feat: restrict access to "LangGraph Agents" provider

### DIFF
--- a/api/server/middleware/accessResources/canAccessAgentFromBody.js
+++ b/api/server/middleware/accessResources/canAccessAgentFromBody.js
@@ -61,7 +61,8 @@ const canAccessAgentFromBody = (options) => {
         if (isProviderOnly) {
           return res.status(403).json({
             error: 'Forbidden',
-            message: 'This endpoint can only be accessed through created agents with proper permissions',
+            message:
+              'This endpoint can only be accessed through created agents with proper permissions',
           });
         }
         agentId = Constants.EPHEMERAL_AGENT_ID;

--- a/api/server/middleware/accessResources/canAccessAgentFromBody.js
+++ b/api/server/middleware/accessResources/canAccessAgentFromBody.js
@@ -50,7 +50,20 @@ const canAccessAgentFromBody = (options) => {
       const { endpoint, agent_id } = req.body;
       let agentId = agent_id;
 
+      // Check if endpoint is in allowedProviders (provider-only endpoints)
+      // These endpoints can only be used through created agents, not via ephemeral access
+      const allowedProviders = req.config?.endpoints?.agents?.allowedProviders || [];
+      const isProviderOnly = allowedProviders.includes(endpoint);
+
       if (!isAgentsEndpoint(endpoint)) {
+        // If this is a provider-only endpoint, completely block direct access
+        // These must go through the agents endpoint, not as standalone requests
+        if (isProviderOnly) {
+          return res.status(403).json({
+            error: 'Forbidden',
+            message: 'This endpoint can only be accessed through created agents with proper permissions',
+          });
+        }
         agentId = Constants.EPHEMERAL_AGENT_ID;
       }
 

--- a/librechat.n1.yml
+++ b/librechat.n1.yml
@@ -73,6 +73,9 @@ mcpServers:
     chatMenu: false
     requiresOAuth: false
 endpoints:
+  agents:
+    allowedProviders:
+      - "LangGraph Agents"
   azureOpenAI:
     # Endpoint-level configuration
     titleModel: "gpt-4o"

--- a/librechat.n2a.yml
+++ b/librechat.n2a.yml
@@ -74,6 +74,9 @@ mcpServers:
     chatMenu: false
     requiresOAuth: false
 endpoints:
+  agents:
+    allowedProviders:
+      - "LangGraph Agents"
   azureOpenAI:
     # Endpoint-level configuration
     titleModel: "gpt-4o"

--- a/librechat.prod.yml
+++ b/librechat.prod.yml
@@ -72,6 +72,9 @@ mcpServers:
     chatMenu: false
     requiresOAuth: false
 endpoints:
+  agents:
+    allowedProviders:
+      - "LangGraph Agents"
   azureOpenAI:
     # Endpoint-level configuration
     titleModel: "gpt-4o"


### PR DESCRIPTION
Adds an allowedProviders config option under endpoints.agents that prevents direct/ephemeral access to specified providers via the agents chat route. Requests to these endpoints must go through an agent created by an admin. 