### PR TITLE
fix: defer body header resolution until after conversationId is generated

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const fetch = require('node-fetch');
 const { logger } = require('@librechat/data-schemas');
+const { resolveHeaders } = require('@librechat/api');
 const {
   countTokens,
   getBalanceConfig,
@@ -75,6 +76,32 @@ class BaseClient {
 
   setOptions() {
     throw new Error("Method 'setOptions' must be implemented.");
+  }
+
+  /**
+   * Resolves dynamic headers that depend on request body fields (conversationId, messageId, etc.)
+   * This is called after conversationId is generated in setMessageOptions
+   * @param {Record<string, string>} [headerTemplates] - Header templates with placeholders to resolve
+   * @returns {Record<string, string>} - Resolved headers
+   */
+  resolveDynamicHeaders(headerTemplates) {
+    if (!headerTemplates || Object.keys(headerTemplates).length === 0) {
+      return {};
+    }
+
+    // Build synthetic body from current client state (like agents endpoint does)
+    const syntheticBody = {
+      conversationId: this.conversationId,
+      parentMessageId: this.parentMessageId,
+      messageId: this.responseMessageId,
+    };
+
+    // Resolve headers with the synthetic body
+    return resolveHeaders({
+      headers: headerTemplates,
+      user: this.options?.req?.user,
+      body: syntheticBody,
+    });
   }
 
   async getCompletion() {

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -875,6 +875,12 @@ class OpenAIClient extends BaseClient {
         opts.organization = process.env.OPENAI_ORGANIZATION;
       }
 
+      // Resolve dynamic headers (body-dependent placeholders) after conversationId is generated
+      if (this.options.headerTemplates) {
+        const dynamicHeaders = this.resolveDynamicHeaders(this.options.headerTemplates);
+        opts.defaultHeaders = { ...opts.defaultHeaders, ...dynamicHeaders };
+      }
+
       let chatCompletion;
       /** @type {OpenAI} */
       const openai = new OpenAI({

--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -103,8 +103,10 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
     headers: resolveHeaders({
       headers: endpointConfig.headers,
       user: req.user,
-      body: req.body,
     }),
+    // Store unresolved header templates for body-dependent placeholders
+    // These will be resolved later in OpenAIClient after conversationId is generated
+    headerTemplates: endpointConfig.headers,
     addParams: endpointConfig.addParams,
     dropParams: endpointConfig.dropParams,
     customParams: endpointConfig.customParams,


### PR DESCRIPTION
Custom endpoint headers using {{LIBRECHAT_BODY_*}} were being resolved at initialization time from req.body, before conversationId and messageId were generated. This caused x-librechat-conversation-id to be empty on first request and agent to fail