### PR TITLE
fix: Tavily rate limiting errors by adding instruction to avoid research endpoint

### DIFF
--- a/librechat.n1.yml
+++ b/librechat.n1.yml
@@ -71,6 +71,7 @@ mcpServers:
       Authorization: "Bearer ${TAVILY_API_KEY}"
     startup: true
     chatMenu: false
+    serverInstructions: "Use Tavily search/news tools only by default. Do NOT use Tavily research or deep-research tools, and do NOT route prompts containing general 'research' wording to those tools. Only use Tavily research/deep-research tools when the user explicitly requests 'deep research'."
     requiresOAuth: false
 endpoints:
   azureOpenAI:

--- a/librechat.n2a.yml
+++ b/librechat.n2a.yml
@@ -72,6 +72,7 @@ mcpServers:
       Authorization: "Bearer ${TAVILY_API_KEY}"
     startup: true
     chatMenu: false
+    serverInstructions: "Use Tavily search/news tools only by default. Do NOT use Tavily research or deep-research tools, and do NOT route prompts containing general 'research' wording to those tools. Only use Tavily research/deep-research tools when the user explicitly requests 'deep research'."
     requiresOAuth: false
 endpoints:
   azureOpenAI:

--- a/librechat.prod.yml
+++ b/librechat.prod.yml
@@ -70,6 +70,7 @@ mcpServers:
       Authorization: "Bearer ${TAVILY_API_KEY}"
     startup: true
     chatMenu: false
+    serverInstructions: "Use Tavily search/news tools only by default. Do NOT use Tavily research or deep-research tools, and do NOT route prompts containing general 'research' wording to those tools. Only use Tavily research/deep-research tools when the user explicitly requests 'deep research'."
     requiresOAuth: false
 endpoints:
   azureOpenAI:


### PR DESCRIPTION
Fix Tavily rate limiting errors by avoiding research endpoint unless user specifically asked for it.
Relates to (INC4243676)