### PR TITLE
feat: add agent support contact information in Landing component

### DIFF
--- a/client/src/components/Chat/Landing.tsx
+++ b/client/src/components/Chat/Landing.tsx
@@ -69,6 +69,7 @@ export default function Landing({ centerFormOnLanding }: { centerFormOnLanding: 
 
   const name = entity?.name ?? '';
   const description = (entity?.description || conversation?.greeting) ?? '';
+  const supportContact = isAgent && entity ? (entity as any).support_contact : null;
 
   const getGreeting = useCallback(() => {
     if (typeof startupConfig?.interface?.customWelcome === 'string') {
@@ -207,6 +208,18 @@ export default function Landing({ centerFormOnLanding }: { centerFormOnLanding: 
         {description && (
           <div className="animate-fadeIn mt-4 max-w-md text-center text-sm font-normal text-text-primary">
             {description}
+          </div>
+        )}
+        {supportContact && (supportContact.name || supportContact.email) && (
+          <div className="animate-fadeIn mt-2 max-w-md text-center text-xs text-text-secondary">
+            {localize('com_agents_contact_support')}:{' '}
+            {supportContact.email ? (
+              <a href={`mailto:${supportContact.email}`} className="text-primary hover:underline">
+                {supportContact.name || supportContact.email}
+              </a>
+            ) : (
+              <span>{supportContact.name}</span>
+            )}
           </div>
         )}
       </div>

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -31,6 +31,7 @@
   "com_agents_code_interpreter": "When enabled, allows your agent to leverage the LibreChat Code Interpreter API to run generated code, including file processing, securely. Requires a valid API key.",
   "com_agents_code_interpreter_title": "Code Interpreter API",
   "com_agents_contact": "Contact",
+  "com_agents_contact_support": "Have questions or feedback? Reach out to",
   "com_agents_copy_link": "Copy Link",
   "com_agents_create_error": "There was an error creating your agent.",
   "com_agents_created_by": "by",


### PR DESCRIPTION
Agent support contact info was previously only visible in the agent marketplace. With the marketplace initially disabled, users had no way to find out who to contact for help. Added a support contact element that displays alongside the agent description when starting a chat. 