### PR TITLE
Add identification-specific LangGraph endpoint configs

### DIFF
--- a/librechat.n1.yml
+++ b/librechat.n1.yml
@@ -151,6 +151,8 @@ endpoints:
     - name: "LangGraph Agents"
       apiKey: "${LANGGRAPH_PROXY_API_KEY}"
       baseURL: "${LANGGRAPH_PROXY_BASE_URL}"
+      headers:
+        x-librechat-conversation-id: "{{LIBRECHAT_BODY_CONVERSATIONID}}"
       models:
         default:
           - langgraph-agent
@@ -159,6 +161,29 @@ endpoints:
       titleEndpoint: azureOpenAI
       titleModel: "gpt-41-mini"
       modelDisplayLabel: "LangGraph Agents"
+      streamRate: 25
+      dropParams:
+        - 'stop'
+        - 'frequency_penalty'
+        - 'presence_penalty'
+        - 'top_p'
+    - name: "LangGraph Agents Identification"
+      apiKey: "${LANGGRAPH_PROXY_API_KEY}"
+      baseURL: "${LANGGRAPH_PROXY_BASE_URL}"
+      headers:
+        x-librechat-conversation-id: "{{LIBRECHAT_BODY_CONVERSATIONID}}"
+        x-user-access-token: "{{LIBRECHAT_OPENID_ACCESS_TOKEN}}"
+        x-user-id: "{{LIBRECHAT_OPENID_USER_ID}}"
+        x-message-id: "{{LIBRECHAT_BODY_MESSAGEID}}"
+        x-parent-message-id: "{{LIBRECHAT_BODY_PARENTMESSAGEID}}"
+      models:
+        default:
+          - langgraph-agent-identification
+        fetch: false
+      titleConvo: true
+      titleEndpoint: azureOpenAI
+      titleModel: "gpt-41-mini"
+      modelDisplayLabel: "LangGraph Agents Identification"
       streamRate: 25
       dropParams:
         - 'stop'

--- a/librechat.n2a.yml
+++ b/librechat.n2a.yml
@@ -152,6 +152,8 @@ endpoints:
     - name: "LangGraph Agents"
       apiKey: "${LANGGRAPH_PROXY_API_KEY}"
       baseURL: "${LANGGRAPH_PROXY_BASE_URL}"
+      headers:
+        x-librechat-conversation-id: "{{LIBRECHAT_BODY_CONVERSATIONID}}"
       models:
         default:
           - langgraph-agent
@@ -160,6 +162,29 @@ endpoints:
       titleEndpoint: azureOpenAI
       titleModel: "gpt-41-mini"
       modelDisplayLabel: "LangGraph Agents"
+      streamRate: 25
+      dropParams:
+        - 'stop'
+        - 'frequency_penalty'
+        - 'presence_penalty'
+        - 'top_p'
+    - name: "LangGraph Agents Identification"
+      apiKey: "${LANGGRAPH_PROXY_API_KEY}"
+      baseURL: "${LANGGRAPH_PROXY_BASE_URL}"
+      headers:
+        x-librechat-conversation-id: "{{LIBRECHAT_BODY_CONVERSATIONID}}"
+        x-user-access-token: "{{LIBRECHAT_OPENID_ACCESS_TOKEN}}"
+        x-user-id: "{{LIBRECHAT_OPENID_USER_ID}}"
+        x-message-id: "{{LIBRECHAT_BODY_MESSAGEID}}"
+        x-parent-message-id: "{{LIBRECHAT_BODY_PARENTMESSAGEID}}"
+      models:
+        default:
+          - langgraph-agent-identification
+        fetch: false
+      titleConvo: true
+      titleEndpoint: azureOpenAI
+      titleModel: "gpt-41-mini"
+      modelDisplayLabel: "LangGraph Agents Identification"
       streamRate: 25
       dropParams:
         - 'stop'

--- a/librechat.prod.yml
+++ b/librechat.prod.yml
@@ -150,6 +150,8 @@ endpoints:
     - name: "LangGraph Agents"
       apiKey: "${LANGGRAPH_PROXY_API_KEY}"
       baseURL: "${LANGGRAPH_PROXY_BASE_URL}"
+      headers:
+        x-librechat-conversation-id: "{{LIBRECHAT_BODY_CONVERSATIONID}}"
       models:
         default:
           - langgraph-agent
@@ -158,6 +160,29 @@ endpoints:
       titleEndpoint: azureOpenAI
       titleModel: "gpt-41-mini"
       modelDisplayLabel: "LangGraph Agents"
+      streamRate: 25
+      dropParams:
+        - 'stop'
+        - 'frequency_penalty'
+        - 'presence_penalty'
+        - 'top_p'
+    - name: "LangGraph Agents Identification"
+      apiKey: "${LANGGRAPH_PROXY_API_KEY}"
+      baseURL: "${LANGGRAPH_PROXY_BASE_URL}"
+      headers:
+        x-librechat-conversation-id: "{{LIBRECHAT_BODY_CONVERSATIONID}}"
+        x-user-access-token: "{{LIBRECHAT_OPENID_ACCESS_TOKEN}}"
+        x-user-id: "{{LIBRECHAT_OPENID_USER_ID}}"
+        x-message-id: "{{LIBRECHAT_BODY_MESSAGEID}}"
+        x-parent-message-id: "{{LIBRECHAT_BODY_PARENTMESSAGEID}}"
+      models:
+        default:
+          - langgraph-agent-identification
+        fetch: false
+      titleConvo: true
+      titleEndpoint: azureOpenAI
+      titleModel: "gpt-41-mini"
+      modelDisplayLabel: "LangGraph Agents Identification"
       streamRate: 25
       dropParams:
         - 'stop'


### PR DESCRIPTION
## Summary
- add a second Conduit-backed LangGraph custom endpoint for identification-enabled agents
- keep the standard LangGraph endpoint limited to conversation continuity headers only
- leave non-YAML LibreChat changes for a later PR

## Testing
- npm run build:data-provider
- npm run build:data-schemas
- npm run build:api
- cd packages/api && npm run test:ci -- --runInBand src/utils/env.spec.ts src/utils/oidc.spec.ts
- cd api && npm run test:ci -- --runInBand app/clients/specs/BaseClient.test.js server/controllers/agents/client.test.js server/services/Config/loadConfigModels.spec.js server/services/Endpoints/custom/initialize.spec.js