### PR TITLE
Feature/aia 2738 generate libre chat capabilities doc

### DIFF
--- a/.github/agents/capability-doc.agent.md
+++ b/.github/agents/capability-doc.agent.md
@@ -1,0 +1,78 @@
+---
+description: "Generate or update Paychex LibreChat capability documentation for a specific environment. Use when updating docs/capabilities-*.md files."
+tools: [read, search, execute, edit]
+argument-hint: "Environment name: n1, n2a, or prod"
+model: "Claude Sonnet 4.6"
+---
+
+You are a documentation agent for Paychex LibreChat. Your job is to generate accurate, end-user-facing capability documents for a specific deployment environment.
+
+## Instructions
+
+Follow these steps in order when invoked with an environment name (n1, n2a, or prod):
+
+### Step 1 — Validate environment
+Confirm the argument is one of: `n1`, `n2a`, `prod`. If not provided or invalid, ask the user to specify.
+
+### Step 2 — Fetch upstream diff
+Run the following to identify which files Paychex has changed relative to upstream LibreChat:
+```bash
+git remote add upstream https://github.com/danny-avila/LibreChat.git 2>/dev/null || true
+git fetch upstream main --depth=1
+git diff --name-status upstream/main..HEAD
+```
+
+Classify results by prefix:
+- `A` — net-new file added by Paychex (not in upstream)
+- `M` — upstream file modified by Paychex
+- `D` — upstream file/feature deleted by Paychex → candidate for **Known Limitations**
+
+### Step 3 — Read environment config
+Read `librechat.{env}.yml` and extract:
+- `modelSpecs.list[]` — all models with `name`, `label`, `description`
+- `mcpServers` — available tools (e.g., Tavily internet search)
+- `interface` toggles — `agents`, `modelSelect`, `parameters`, `presets`, `runCode`
+- `endpoints` — provider names, streaming behavior, `addParams`, `dropParams`, `streamRate`
+
+### Step 4 — Read infrastructure config
+Read `az_container_app_definitions/{env}_container_app_definition.yml` and extract:
+- Custom domain (the user-facing URL)
+- Authentication login method (e.g., Single Sign-On via Paychex corporate account) — do **not** record client IDs, tenant IDs, issuer URLs, or scopes
+- RAG API container presence (look for a second container named `conpairag` or similar)
+- Any other environment-specific env vars that have a direct, visible impact on user-facing behaviour (exclude internal infra settings)
+
+### Step 5 — Load Paychex customization reference
+Read `.github/instructions/capability-doc-context.instructions.md` for the canonical list of Paychex-added features and the config key → user-facing feature mapping table.
+
+### Step 6 — Classify Paychex-specific code
+
+For each file in the diff from Step 2, read it and determine its user-facing impact. **Do not assume a file is a Paychex addition just because it exists in the repo** — confirm its prefix in the diff output.
+
+- **`A` (net-new):** Read the file. Summarize the user-facing capability it introduces. Include in the **Paychex-Specific Additions** section of the output doc.
+- **`M` (modified):** Read the file. To understand what changed, also fetch the upstream version via `git show upstream/main:<path>`. Describe the user-facing change. Include in **Paychex-Specific Additions** only if the modification introduces or meaningfully changes a user-facing capability.
+- **`D` (deleted):** Describe what the user can no longer do. Include in the **Known Limitations** section.
+
+Focus on files under `client/src/`, `api/server/`, and `config/` — these are most likely to affect end-user behavior. Skip build configs, test files, CI/CD workflows, and infrastructure files (`.github/workflows/`, `az_container_app_definitions/`, `Dockerfile`, lockfiles, etc.).
+
+Consult `.github/instructions/capability-doc-context.instructions.md` for guidance on how to label specific patterns you find (e.g., how to label People Picker based on env vars).
+
+### Step 7 — Read the output template
+Read `docs/capabilities-template.md` to understand the required document structure.
+
+### Step 8 — Generate the capability document
+Create or overwrite `docs/capabilities-{env}.md` following the template exactly.
+
+Rules:
+- Set `Last updated:` to today's date in `YYYY-MM-DD` format
+- Set `Environment URL:` to the domain found in the container app definition
+- List **all** models from `modelSpecs.list[]` in the Models table
+- Map `addParams.disableStreaming: true` or `dropParams: [stream, streaming]` → Streaming = No
+- Map `streamRate` present → Streaming = Yes
+- For features enabled by default in upstream LibreChat that are NOT explicitly disabled in this fork's config, list them as **Enabled**
+- Document end-user capabilities only — omit container specs, env vars, subscription IDs, and pipeline details
+- In the **Paychex-Specific Additions** section, only list items confirmed as net-new (`A`) or meaningfully modified (`M`) in the diff. Do not list upstream features that are present but unmodified.
+- In the **Known Limitations** section, include an entry for each significant upstream feature deleted (`D`) by Paychex that users would otherwise expect to find.
+- **Do not mention Pendo, Segment, or any analytics/tracking additions** in any section of the document. Omit these entirely.
+- **Authentication section:** Describe only the login method visible to users (e.g., "Single Sign-On via your Paychex corporate account"). Do not include client IDs, tenant IDs, issuer URLs, scopes, or any internal configuration values.
+- **People Picker and Agent Builder are admin-only features.** Do not list them as available capabilities. Instead, add a row to **Known Limitations** stating each is accessible to administrators only, not general users.
+- **Role/permission migration scripts:** Do not mention specific role names or internal permission structures. Only note the general user impact (e.g., "access to certain features is determined by your assigned role") if relevant.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,45 @@
+# Paychex LibreChat — Copilot Workspace Instructions
+
+This is a Paychex fork of the open-source LibreChat project.
+
+**Upstream repository:** https://github.com/danny-avila/LibreChat
+
+## Environments
+
+| Short Name | Domain | Config File | Container App Definition |
+|------------|--------|-------------|--------------------------|
+| n1 | play.ain1.paychex.com | `librechat.n1.yml` | `az_container_app_definitions/n1_container_app_definition.yml` |
+| n2a | play.ain2a.paychex.com | `librechat.n2a.yml` | `az_container_app_definitions/n2a_container_app_definition.yml` |
+| prod | play.ai.paychex.com | `librechat.prod.yml` | `az_container_app_definitions/prod_container_app_definition.yml` |
+
+## Repository Layout
+
+- `librechat.{env}.yml` — Per-environment LibreChat configuration (models, MCP servers, interface toggles, endpoints)
+- `az_container_app_definitions/{env}_container_app_definition.yml` — Azure Container App definitions (domain, auth, secrets)
+- `.github/workflows/` — GitHub Actions CI/CD pipelines per environment
+- `api/server/middleware/` — Paychex-specific server middleware
+- `client/src/hooks/` — Paychex-specific React hooks (Pendo analytics, RBAC)
+- `PAYCHEX_README.md` — Paychex-specific documentation and workflow guide
+
+## Branching
+
+- `develop` — Default development branch; auto-deploys to N2A on push
+- `release/*` — Release branches; deploys to N1 on push
+- `feature/*`, `bugfix/*`, `hotfix/*`, `upstream/*` — Short-lived branches
+
+## Capability Documentation Tasks
+
+When generating or updating capability documentation (`docs/capabilities-*.md`):
+
+1. Follow the instructions in `.github/agents/capability-doc.agent.md`
+2. Use `docs/capabilities-template.md` as the output schema
+3. Reference `.github/instructions/capability-doc-context.instructions.md` for Paychex customization mappings
+4. Document end-user capabilities only — omit container specs, env vars, and pipeline details
+
+## Paychex-Specific Customizations
+
+- **People Picker (Entra ID)**: `api/server/middleware/checkPeoplePickerAccess.js` — upstream middleware modified to support Entra ID Graph API
+- **Pendo Analytics**: `client/src/hooks/Pendo/` — net-new addition; not in upstream
+- **Agent & Prompt Role Migrations**: `config/migrate-agent-permissions.js`, `config/migrate-prompt-permissions.js` — Paychex-customized role definitions
+- **Auth**: Azure Entra ID OpenID Connect (environment-specific client IDs)
+- **CI/CD**: Azure Container Apps via GitHub Actions

--- a/.github/instructions/capability-doc-context.instructions.md
+++ b/.github/instructions/capability-doc-context.instructions.md
@@ -1,0 +1,73 @@
+---
+description: "Context for Paychex LibreChat capability documentation generation and review. Use when writing or reviewing docs/capabilities-*.md files."
+applyTo: "docs/capabilities-*.md"
+---
+
+# Paychex LibreChat Capability Doc Context
+
+This file provides canonical reference data for generating and reviewing Paychex LibreChat capability documents.
+
+## Labeling Guidance for Discovered Changes
+
+After running `git diff --name-status upstream/main..HEAD`, read each changed file to determine its user-facing impact. Only list a feature as Paychex-specific if its file is `A` or `M` in the diff.
+
+Use the following rules when labeling specific patterns found during discovery:
+
+- **People Picker middleware** (any modified file matching `checkPeoplePickerAccess` or similar): This is an **admin-only** feature — list it in the **Known Limitations** section as inaccessible to general users. Do not include it in Paychex-Specific Additions.
+- **Analytics hooks** (net-new files under `client/src/hooks/` tracking user interactions): **Omit entirely** from the generated doc. Do not mention analytics providers such as Pendo or Segment.
+- **Role/permission migration scripts** (`config/migrate-*-permissions.js`): Do not mention specific role names or permission details. Only describe the general user impact if any (e.g., "role-based access control determines which features a user can access"). Omit internal role names.
+- **Auth**: Azure Entra ID OpenID Connect is always present — describe only the **login method visible to users** (e.g., "Single Sign-On via your Paychex corporate account"). Do not include client IDs, tenant IDs, issuer URLs, scopes, or any other internal configuration.
+- **Public resource sharing** (deleted files `useCanSharePublic.ts` and `checkSharePublicAccess.js`): These guard the `SHARE_PUBLIC` permission on **resources** (agents, prompts, MCP servers) — not on conversations. Their deletion means users can no longer mark agents or prompts as publicly visible to everyone. Do **not** conflate this with conversation link sharing, which is governed by the `ALLOW_SHARED_LINKS` / `ALLOW_SHARED_LINKS_PUBLIC` env vars in the container definition. List the resource-sharing removal in **Known Limitations** as "Agent/Prompt public sharing removed".
+
+## Config Key → User-Facing Feature Mapping
+
+Use this table to translate YAML config keys into end-user capability descriptions:
+
+| Config Key | User-Facing Feature |
+|------------|---------------------|
+| `interface.agents: true` | AI Agents config enabled — but the **Agent Builder is an admin-only feature**; list it in **Known Limitations** as not accessible to general users |
+| `modelSpecs.addedEndpoints` includes `agents` (without admin restriction) | LangGraph Agents available for general users via the model selector |
+| `interface.modelSelect: true` | Users can switch between available AI models |
+| `interface.parameters: true` | Users can adjust model parameters (temperature, max tokens, etc.) |
+| `interface.presets: true` | Conversation presets available — save and reuse prompt configurations |
+| `interface.runCode: false` | Code execution (sandboxed runtime) is **disabled** |
+| `mcpServers` with Tavily | Internet/web search capability via Tavily MCP |
+| `modelSpecs.addedEndpoints` includes `agents` | Agent builder is accessible from the model selector |
+| `addParams.disableStreaming: true` | Model does **not** support streaming responses — full response delivered at once |
+| `dropParams: [stream, streaming]` | Streaming disabled for this model endpoint |
+| `streamRate: 25` | Streaming enabled — responses appear word-by-word |
+| `directEndpoint: true` | Model connects directly to provider, not through Azure OpenAI |
+
+## Default-Enabled Upstream LibreChat Features
+
+The following features are enabled by default in upstream LibreChat. Assume they are **enabled** in this fork unless explicitly disabled in the environment config or interface toggles:
+
+- **Conversation search** — Full-text search powered by Meilisearch
+- **File attachments/uploads** — Attach files to conversations for context
+- **RAG (Retrieval-Augmented Generation)** — Upload documents to query against (requires RAG API container)
+- **Conversation sharing** — Generate a shareable link to a conversation; anyone with the link can view it (controlled by `ALLOW_SHARED_LINKS` and `ALLOW_SHARED_LINKS_PUBLIC` env vars, both of which default to `true` when unset)
+- **Conversation export** — Export conversations as JSON or markdown
+- **Bookmarks** — Bookmark important messages
+- **Multi-language support (i18n)** — Interface available in multiple languages
+- **Code artifacts** — Render and display code blocks with syntax highlighting
+- **LaTeX rendering** — Mathematical equations rendered with KaTeX
+- **Markdown rendering** — Full markdown support in messages
+- **Conversation branching** — Fork conversations from any message
+- **Message editing** — Edit previously sent messages and regenerate responses
+
+## Environment URLs
+
+| Environment | URL |
+|-------------|-----|
+| N1 | https://play.ain1.paychex.com |
+| N2A | https://play.ain2a.paychex.com |
+| Prod | https://play.ai.paychex.com |
+
+## Streaming Behavior by Provider
+
+| Provider | Streaming Default | Notes |
+|----------|------------------|-------|
+| Azure OpenAI (gpt-4o, gpt-41, etc.) | Yes | Standard SSE streaming |
+| Gemini 2.5 Pro / Flash | No | `disableStreaming: true` + `dropParams: [stream, streaming]` |
+| Claude Sonnet 4.5 | Yes | `streamRate: 25` — Kong translates to OpenAI SSE format |
+| LangGraph Agents | Yes | `streamRate: 25` |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -5,6 +5,7 @@ name: Copilot Setup Steps
 # See: https://docs.github.com/en/copilot/customizing-copilot/customizing-the-development-environment-for-copilot-coding-agent
 
 on:
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: paychex-ai-platform-arc-nonprod
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -30,4 +30,4 @@ jobs:
       - name: Set up Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 'lts/*'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,32 @@
+name: Copilot Setup Steps
+
+# Environment setup for the Copilot coding agent.
+# This workflow runs before the agent starts working on capability documentation tasks.
+# See: https://docs.github.com/en/copilot/customizing-copilot/customizing-the-development-environment-for-copilot-coding-agent
+
+on:
+  workflow_dispatch:
+
+jobs:
+  copilot-setup-steps:
+    runs-on: paychex-ai-platform-arc-nonprod
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Add upstream LibreChat remote
+        run: |
+          git remote add upstream https://github.com/danny-avila/LibreChat.git 2>/dev/null || true
+          echo "Upstream remote configured"
+
+      - name: Fetch upstream main branch
+        run: |
+          git fetch upstream main --depth=1
+          echo "Upstream main fetched"
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'

--- a/.github/workflows/update-capability-docs.yml
+++ b/.github/workflows/update-capability-docs.yml
@@ -1,0 +1,90 @@
+name: Update Capability Docs
+
+# Triggers capability documentation generation by creating GitHub issues assigned to Copilot.
+# Copilot coding agent picks up the issue, runs the generation workflow, and opens a PR.
+#
+# Trigger mapping:
+#   - push to develop        → N2A doc update
+#   - push to release/*      → N1 doc update
+#   - workflow_dispatch      → manual, choose environment (n1, n2a, prod, or all)
+#
+# Note: Prod doc updates are manual dispatch only — never auto-triggered.
+
+on:
+  push:
+    branches:
+      - develop
+      - release/*
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to update documentation for"
+        required: true
+        default: "n2a"
+        type: choice
+        options:
+          - n1
+          - n2a
+          - prod
+          - all
+
+permissions:
+  issues: write
+
+jobs:
+  determine-environments:
+    name: Determine Target Environments
+    runs-on: paychex-ai-platform-arc-nonprod
+    outputs:
+      environments: ${{ steps.set-envs.outputs.environments }}
+    steps:
+      - name: Set target environments
+        id: set-envs
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            INPUT="${{ github.event.inputs.environment }}"
+            if [ "$INPUT" = "all" ]; then
+              echo 'environments=["n1","n2a","prod"]' >> $GITHUB_OUTPUT
+            else
+              echo "environments=[\"$INPUT\"]" >> $GITHUB_OUTPUT
+            fi
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            BRANCH="${{ github.ref_name }}"
+            if [ "$BRANCH" = "develop" ]; then
+              echo 'environments=["n2a"]' >> $GITHUB_OUTPUT
+            elif echo "$BRANCH" | grep -q "^release/"; then
+              echo 'environments=["n1"]' >> $GITHUB_OUTPUT
+            else
+              echo 'environments=[]' >> $GITHUB_OUTPUT
+            fi
+          fi
+
+  create-issues:
+    name: Create Copilot Issue for ${{ matrix.environment }}
+    needs: determine-environments
+    runs-on: paychex-ai-platform-arc-nonprod
+    if: ${{ needs.determine-environments.outputs.environments != '[]' }}
+    strategy:
+      matrix:
+        environment: ${{ fromJson(needs.determine-environments.outputs.environments) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Create Copilot issue for ${{ matrix.environment }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENV: ${{ matrix.environment }}
+        run: |
+          # Read the issue template and substitute {ENV} placeholder
+          BODY=$(cat docs/update-capability-doc.md \
+            | sed '/^---$/,/^---$/d' \
+            | sed "s/{ENV}/$ENV/g")
+
+          gh issue create \
+            --title "Update ${ENV^^} Capability Documentation" \
+            --body "$BODY" \
+            --label "documentation,copilot" \
+            --assignee "copilot"
+
+          echo "Created capability doc issue for environment: $ENV"

--- a/docs/capabilities-n2a.md
+++ b/docs/capabilities-n2a.md
@@ -1,0 +1,93 @@
+# Paychex LibreChat — N2A Capabilities
+
+> **Last updated:** 2026-04-08
+> **Environment URL:** https://play.ain2a.paychex.com
+
+---
+
+## Available Models
+
+| Model | Provider | Description | Streaming | Notes |
+|-------|----------|-------------|-----------|-------|
+| GPT-4o | Azure OpenAI | For daily tasks with a quick response time. | Yes | Default model |
+| GPT-4o Mini | Azure OpenAI | Offers simpler, more instant responses. | Yes | |
+| GPT-4.1 | Azure OpenAI | For complex reasoning and coding. | Yes | |
+| GPT-4.1 Mini | Azure OpenAI | A faster, more lightweight version of GPT-4.1. | Yes | |
+| GPT-5 | Azure OpenAI | For advanced tasks with the highest accuracy and reasoning depth. | Yes | |
+| Gemini 2.5 Pro | Google (GCP Vertex AI) | Quickly analyze complex, mixed media content. | No | Full response delivered at once; `disableStreaming: true` |
+| Gemini 2.5 Flash | Google (GCP Vertex AI) | A faster, more lightweight version of Gemini 2.5 Pro. | No | Full response delivered at once; `disableStreaming: true` |
+| Claude Sonnet 4.5 (Limited) | Anthropic (GCP Vertex AI) | For extended reasoning, coding, and automation. This model is being evaluated and can be used a limited number of times. | Yes | Rate-limited; streaming via Kong SSE translation |
+
+---
+
+## Feature Configuration
+
+### Core Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Conversation search | Enabled | Full-text search powered by Meilisearch |
+| File attachments / uploads | Enabled | Attach files to conversations for context |
+| RAG (Retrieval-Augmented Generation) | Enabled | Upload documents to query against; powered by the co-located RAG API container |
+| Conversation sharing | Enabled | Generate a shareable link to a conversation; anyone with the link can view it |
+| Conversation export | Enabled | Export conversations as JSON or Markdown |
+| Bookmarks | Enabled | Bookmark important messages |
+| Multi-language support (i18n) | Enabled | Interface available in multiple languages |
+| Code artifacts | Enabled | Render and display code blocks with syntax highlighting |
+| LaTeX rendering | Enabled | Mathematical equations rendered with KaTeX |
+| Markdown rendering | Enabled | Full Markdown support in messages |
+| Conversation branching | Enabled | Fork conversations from any message |
+| Message editing | Enabled | Edit previously sent messages and regenerate responses |
+| Model selection | Enabled | Users can switch between available AI models |
+| Model parameters | Enabled | Users can adjust temperature, max tokens, and other parameters |
+| Presets | Enabled | Save and reuse prompt/model configurations |
+| Prompts library | Enabled | Create and share reusable prompts |
+| Code execution (sandboxed runtime) | Disabled | `interface.runCode: false` |
+
+### AI Agents
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| AI Agents | Enabled | Pre-built agents are available for use; powered by a Paychex-hosted LangGraph proxy with streaming responses |
+
+### Tools & Integrations
+
+| Tool | Status | Notes |
+|------|--------|-------|
+| Internet Search (Tavily) | Enabled | Web search via Tavily MCP server; supports standard search and `/deep-research` mode |
+| Document RAG | Enabled | Upload and query PDF, text, and other documents using Azure OpenAI embeddings (`text-embedding-ada-002`) |
+
+---
+
+## Authentication
+
+- **Login method:** Single Sign-On via your Paychex corporate account
+- **Email/password login:** Enabled (for pre-provisioned accounts; self-registration is disabled)
+- **Self-registration:** Disabled
+
+---
+
+## Paychex-Specific Additions
+
+| Feature | Description |
+|---------|-------------|
+| UI Label Overrides | Net-new English translation override file that customizes several UI labels — including code interpreter, file search, SharePoint upload, and code artifact descriptions — to match Paychex terminology. |
+| Role-Based Access Control | Modified permission migration scripts apply Paychex-specific access tiers to agents and prompt groups. Access to certain features is determined by your assigned role. |
+
+---
+
+## Known Limitations
+
+| Limitation | Detail |
+|------------|--------|
+| Code execution disabled | The sandboxed code interpreter is turned off. Users cannot execute code directly from the chat interface. |
+| Gemini 2.5 Pro — no streaming | Responses are delivered in full once generation completes; no word-by-word streaming. |
+| Gemini 2.5 Flash — no streaming | Responses are delivered in full once generation completes; no word-by-word streaming. |
+| Claude Sonnet 4.5 — rate-limited | Actively being evaluated; users are limited to a small number of requests. Exceeding the limit returns an error. |
+| Agent Builder — admin only | The Agent Builder (custom agent creation) is accessible to administrators only. General users cannot create or configure agents. |
+| People Picker — admin only | The People Picker (directory search for conversation sharing) is accessible to administrators only and is not available to general users. |
+| Agent/Prompt public sharing removed | The ability for users to mark agents or prompts as publicly shared with everyone has been removed. Resource sharing is limited to explicitly granted individuals or groups. |
+| Mermaid diagram rendering removed | Mermaid diagram code blocks will not render as visual diagrams. |
+| Plugin / tool marketplace removed | Users cannot browse or install third-party tools from within the app. |
+| User API key management removed | Users cannot generate personal API keys. |
+| Resumable streaming removed | If a network connection drops mid-response, the response does not automatically resume. |

--- a/docs/capabilities-template.md
+++ b/docs/capabilities-template.md
@@ -1,0 +1,74 @@
+# Paychex LibreChat — {Environment Name} Capabilities
+
+> **Last updated:** {YYYY-MM-DD}
+> **Environment URL:** https://{domain}
+
+---
+
+## Available Models
+
+Populate from `modelSpecs.list[]` in `librechat.{env}.yml`. One row per model.
+Streaming: derive from endpoint config — `disableStreaming: true` or `dropParams: [stream]` → No; `streamRate` present → Yes; Azure OpenAI default → Yes.
+
+| Model | Provider | Description | Streaming | Notes |
+|-------|----------|-------------|-----------|-------|
+| {label} | {provider} | {description} | Yes / No | {any notes} |
+
+---
+
+## Feature Configuration
+
+### Core Features
+
+Populate from upstream defaults and environment config. See `capability-doc-context.instructions.md` for the full list of default-enabled upstream features and the config key → status mapping.
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| {feature name} | Enabled / Disabled | {notes} |
+
+### AI Agents
+
+Populate based on `interface.agents` toggle and `modelSpecs.addedEndpoints`.
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| {feature name} | Enabled / Disabled | {notes} |
+
+### Tools & Integrations
+
+Populate from `mcpServers` in `librechat.{env}.yml` and RAG API container presence in the container app definition.
+
+| Tool | Status | Notes |
+|------|--------|-------|
+| {tool name} | Enabled / Disabled | {notes} |
+
+---
+
+## Authentication
+
+Populate from `az_container_app_definitions/{env}_container_app_definition.yml`. Describe only the login experience visible to end users — do **not** include client IDs, tenant IDs, issuer URLs, scopes, or any internal configuration.
+
+- **Login method:** {e.g., Single Sign-On via your Paychex corporate account}
+- **Email/password login:** {Enabled / Disabled}
+- **Self-registration:** {Enabled / Disabled}
+
+---
+
+## Paychex-Specific Additions
+
+Populate from the `A` (net-new) and `M` (meaningfully modified) entries in `git diff --name-status upstream/main..HEAD`.
+See `capability-doc-context.instructions.md` for the canonical classification of each file.
+
+| Feature | Description |
+|---------|-------------|
+| {feature name} | {description} |
+
+---
+
+## Known Limitations
+
+Include one row for each: streaming-disabled model, disabled interface toggle, deleted upstream feature (`D` in diff), and admin-only feature (People Picker, Agent Builder).
+
+| Limitation | Detail |
+|------------|--------|
+| {limitation} | {detail} |

--- a/docs/update-capability-doc.md
+++ b/docs/update-capability-doc.md
@@ -21,7 +21,7 @@ Follow these steps exactly:
 4. **Run** the upstream diff to identify Paychex-changed files:
    ```bash
    git remote add upstream https://github.com/danny-avila/LibreChat.git 2>/dev/null || true
-   git fetch upstream main --depth=1
+   git rev-parse --verify upstream/main 2>/dev/null || git fetch upstream main --depth=1
    git diff --name-status upstream/main..HEAD
    ```
    Classify by prefix: `A` = net-new Paychex addition, `M` = modified upstream file, `D` = deleted upstream feature (add to Known Limitations).

--- a/docs/update-capability-doc.md
+++ b/docs/update-capability-doc.md
@@ -1,0 +1,51 @@
+---
+name: "Update Capability Documentation"
+about: "Trigger Copilot to generate or update a capability doc for a specific environment."
+labels: ["documentation", "copilot"]
+---
+
+## Task
+
+Generate or update the capability documentation for the **{ENV}** environment.
+
+## Instructions for Copilot
+
+Follow these steps exactly:
+
+1. **Read** `.github/agents/capability-doc.agent.md` for the full generation instructions and step-by-step workflow.
+
+2. **Read** `.github/instructions/capability-doc-context.instructions.md` for the canonical list of Paychex-specific customizations and the config key → user-facing feature mapping table.
+
+3. **Read** `docs/capabilities-template.md` for the required output document structure.
+
+4. **Run** the upstream diff to identify Paychex-changed files:
+   ```bash
+   git remote add upstream https://github.com/danny-avila/LibreChat.git 2>/dev/null || true
+   git fetch upstream main --depth=1
+   git diff --name-status upstream/main..HEAD
+   ```
+   Classify by prefix: `A` = net-new Paychex addition, `M` = modified upstream file, `D` = deleted upstream feature (add to Known Limitations).
+
+5. **Read** `librechat.{ENV}.yml` — extract all models, MCP servers, interface toggles, and endpoint streaming configuration.
+
+6. **Read** `az_container_app_definitions/{ENV}_container_app_definition.yml` — extract domain URL, auth config, and RAG API container presence.
+
+7. **Check** for Paychex-specific code changes using the `--name-status` diff output. Only treat a file as a Paychex addition if it has prefix `A` (net-new) or `M` (meaningfully modified):
+   - `client/src/hooks/Pendo/` — confirmed net-new (`A`); **omit from the doc** — do not mention analytics additions
+   - `api/server/middleware/checkPeoplePickerAccess.js` — modified (`M`); **admin-only feature** — list in Known Limitations as not accessible to general users; do not include in Paychex-Specific Additions
+   - `config/migrate-agent-permissions.js` — modified (`M`); do **not** mention specific role names or permission details; only note the general user impact if any
+   - Do **not** list `requireLdapAuth.js` or `client/src/hooks/Roles/` — both are unmodified upstream files
+   - Check for **deleted** (`D`) upstream feature directories (e.g., `SidePanel/MCPBuilder/`) and add each to Known Limitations
+   - **Agent Builder** (`interface.agents: true`) is an **admin-only feature** — list in Known Limitations; do not list as a general user capability
+
+8. **Generate** `docs/capabilities-{ENV}.md` following the template exactly. Set `Last updated:` to today's date.
+
+## Environment
+
+**Target environment:** `{ENV}`
+
+Valid values: `n1`, `n2a`, `prod`
+
+## Output
+
+Create or update: `docs/capabilities-{ENV}.md`


### PR DESCRIPTION
Added copilot instructions and docs for generating environment specific Paychex LibreChat capability docs.

These outline the various models and enabled/disabled features in an environment.
Added github workflows (needs testing and discussion on when they should be triggered) for auto-generating the documentation.  My thinking is that only the prod doc would be auto-generated and triggered anytime a branch is pushed to main (I'm assuming this is when the code would then be deployed to Prod).

Need to discuss where/how the generated doc should be deployed for ai-literacy agent to fetch/use it.

To test out locally:
- Pull branch down
- In VS Code GitHub Copilot chat window, click the agent selector dropdown and select "capability-doc" agent.
- Type in the environment you want to generate a doc for (n2a, n1, prod)
- Hit enter
- Agent will determine differences/configs for that environment and generate the doc in /docs folder.
