### PR TITLE
fix: reduce MCP SSE transient error log noise and prevent reconnectio…

### DIFF
--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -1084,7 +1084,11 @@ export class MCPConnection extends EventEmitter {
         ? 'Transport error (transient, will reconnect)'
         : 'Transport error (may require manual intervention)';
 
-      logger.error(`${this.getLogPrefix()} ${errorLabel}: ${errorMessage}`, errorContext);
+      if (isTransient) {
+        logger.warn(`${this.getLogPrefix()} ${errorLabel}: ${errorMessage}`, errorContext);
+      } else {
+        logger.error(`${this.getLogPrefix()} ${errorLabel}: ${errorMessage}`, errorContext);
+      }
 
       this.emit('connectionChange', 'error');
     };
@@ -1099,6 +1103,16 @@ export class MCPConnection extends EventEmitter {
     );
     this.agents = [];
     await Promise.all(closing);
+  }
+
+  /**
+   * Signals the reconnection loop to stop without closing the transport.
+   * Call this before disconnect() when the connection is intentionally torn down
+   * (e.g. after a temporary inspection connection) to prevent the background
+   * handleReconnection() loop from continuing after disconnect() returns.
+   */
+  public stopReconnecting(): void {
+    this.shouldStopReconnecting = true;
   }
 
   public async disconnect(resetCycleTracking = true): Promise<void> {

--- a/packages/api/src/mcp/registry/MCPServerInspector.ts
+++ b/packages/api/src/mcp/registry/MCPServerInspector.ts
@@ -85,7 +85,10 @@ export class MCPServerInspector {
         this.fetchToolFunctions(),
       ]);
 
-      if (tempConnection) await this.connection.disconnect();
+      if (tempConnection) {
+        this.connection.stopReconnecting();
+        await this.connection.disconnect();
+      }
     }
   }
 

--- a/packages/api/src/mcp/registry/__tests__/MCPServerInspector.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServerInspector.test.ts
@@ -328,7 +328,8 @@ describe('MCPServerInspector', () => {
         dbSourced: false,
       });
 
-      // Verify temporary connection was disconnected
+      // Verify temporary connection was stopped and disconnected
+      expect(tempMockConnection.stopReconnecting).toHaveBeenCalled();
       expect(tempMockConnection.disconnect).toHaveBeenCalled();
 
       // Verify result is correct
@@ -364,7 +365,8 @@ describe('MCPServerInspector', () => {
       // Verify factory was NOT called
       expect(MCPConnectionFactory.create).not.toHaveBeenCalled();
 
-      // Verify provided connection was NOT disconnected
+      // Verify provided connection was NOT stopped or disconnected
+      expect(mockConnection.stopReconnecting).not.toHaveBeenCalled();
       expect(mockConnection.disconnect).not.toHaveBeenCalled();
     });
   });

--- a/packages/api/src/mcp/registry/__tests__/mcpConnectionsMock.helper.ts
+++ b/packages/api/src/mcp/registry/__tests__/mcpConnectionsMock.helper.ts
@@ -33,6 +33,7 @@ export function createMockConnection(serverName: string): jest.Mocked<MCPConnect
   return {
     client: mockClient,
     disconnect: jest.fn().mockResolvedValue(undefined),
+    stopReconnecting: jest.fn(),
   } as unknown as jest.Mocked<MCPConnection>;
 }
 


### PR DESCRIPTION
I saw a lot of new splunk log errors that were showing up. This is related to changes in 0.8.2, this PR will fix those error messages, and convert the messages that are less impactful to warnings rather than errors.


fix: reduce MCP SSE transient error log noise and prevent reconnection storm after inspection
- Log transient SSE transport errors at warn instead of error level to reduce Splunk noise;
  non-transient errors (DNS failure, ECONNREFUSED) remain at error level
- Add MCPConnection.stopReconnecting() to allow callers to halt the background reconnection
  loop before disconnecting; prevents the loop from outliving temporary inspection connections
- Call stopReconnecting() before disconnect() in MCPServerInspector for temp connections,
  closing the race condition where a dropped SSE during inspection triggered a reconnection
  storm under the placeholder 'temp_server_name' identity
- Add stopReconnecting to the shared MCPConnection mock helper and assert it is called (or not)
  for temp vs. provided connections in MCPServerInspector tests

Made-with: Cursor