### PR TITLE
fix: Convert image format from OpenAI to Anthropic for custom Claude endpoints

### DIFF
--- a/.github/agents/upstream-merge.agent.md
+++ b/.github/agents/upstream-merge.agent.md
@@ -76,6 +76,7 @@ For each conflicted file, determine its risk level:
 - `api/app/clients/BaseClient.js` — filterCrossProviderToolCalls
 - `api/server/services/start/tools.js` — sanitizeSchemaMetadata  
 - `api/server/services/MCP.js` — Gemini custom endpoint detection
+- `api/server/services/Files/images/encode.js` — Anthropic image encoding; `includes('claude')||includes('anthropic')` block must appear before `VisionModes.agents` early-return
 - `Dockerfile` — && error handling
 - `**/package.json` — xlsx must use npm registry
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -69,6 +69,11 @@ When working with code, always preserve these critical Paychex customizations:
 - **Purpose:** Build stops on first error instead of masking failures
 - **Critical:** YES - Prevents broken builds from being deployed
 
+### 8. Anthropic Image Encoding for Custom Endpoints (api/server/services/Files/images/encode.js)
+- **Pattern:** `effectiveEndpoint.toLowerCase().includes('claude') || effectiveEndpoint.toLowerCase().includes('anthropic')`
+- **Purpose:** Converts image parts to Anthropic-native format (`type: 'image'`, `source: { base64 }`) for both the native `anthropic` endpoint and custom endpoints whose name contains "claude" or "anthropic". The conversion block is placed **before** the `VisionModes.agents` early-return so agent-path uploads are also converted correctly.
+- **Critical:** YES - Image uploads to any Claude/Anthropic endpoint throw a 400 error without this
+
 ## Upstream Merge Process
 
 When merging upstream LibreChat releases:
@@ -85,6 +90,7 @@ When merging upstream LibreChat releases:
 - `api/app/clients/BaseClient.js` — Contains `filterCrossProviderToolCalls`
 - `api/server/services/start/tools.js` — Contains `sanitizeSchemaMetadata`
 - `api/server/services/MCP.js` — Custom Gemini endpoint detection
+- `api/server/services/Files/images/encode.js` — Anthropic image encoding; block order relative to `VisionModes.agents` is critical
 - `Dockerfile` — Build error handling
 - `package.json` files — Dependency versions (use npm registry for xlsx, not CDN)
 

--- a/.github/instructions/merge-process.instructions.md
+++ b/.github/instructions/merge-process.instructions.md
@@ -22,6 +22,7 @@ These customizations MUST be preserved during upstream merges. Verify after ever
 | Declarative Tools UI | `client/src/components/Chat/Input/ToolsDropdown.tsx` | `label:`, `description:`, `icon:` properties | Code organization (non-breaking) |
 | Dockerfile Error Handling | `Dockerfile` | `&&` operators (not `;`) | Prevents masked build failures - critical for CI/CD |
 | xlsx Package | `api/package.json`, `packages/api/package.json` | `"xlsx": "^0.18.5"` (npm registry, not CDN) | CDN returns 403 errors - builds fail without this |
+| Anthropic Image Encoding | `api/server/services/Files/images/encode.js` | `includes('claude') \|\| includes('anthropic')` (before `VisionModes.agents` block) | Custom Claude/Anthropic endpoints get 400 errors on image uploads without this; block order matters |
 
 ## Merge Conflict Decision Matrix
 
@@ -55,6 +56,7 @@ Apply this matrix when resolving each conflict:
 - `api/app/clients/BaseClient.js`
 - `api/server/services/start/tools.js`
 - `api/server/services/MCP.js`
+- `api/server/services/Files/images/encode.js`
 - `Dockerfile`
 - `api/package.json`
 - `packages/api/package.json`

--- a/.github/instructions/paychex-customizations.instructions.md
+++ b/.github/instructions/paychex-customizations.instructions.md
@@ -242,6 +242,16 @@ Complete catalog of Paychex-specific modifications to LibreChat.
 - **Criticality:** WARNING — App functions without it, but users' model selection is silently reset on every new conversation
 - **Added:** v0.8.4 post-merge restoration
 
+**25. Anthropic Image Encoding for Custom Endpoints**
+- **File:** `api/server/services/Files/images/encode.js`
+- **Function:** `encodeAndFormat()`
+- **Pattern:** `effectiveEndpoint.toLowerCase().includes('claude') || effectiveEndpoint.toLowerCase().includes('anthropic')`
+- **Purpose:** Converts uploaded image parts to Anthropic-native format (`type: 'image'`, `source: { type: 'base64', ... }`) for both the native `anthropic` endpoint **and** custom endpoints whose name contains "claude" or "anthropic" (e.g. `"Claude Sonnet 4.5"`). Without this, the `image_url` OpenAI-style part is sent to the Anthropic API, which rejects it with a 400 error.
+- **Also fixes:** The Anthropic conversion block is now placed **before** the `VisionModes.agents` early-return so it is reachable for agent-path uploads (previously dead code for agents). Google formatting remains after the agents check, unaffected.
+- **Criticality:** CRITICAL — Image uploads to any Claude/Anthropic endpoint throw a 400 error without this
+- **Added:** April 2026 bugfix
+- **Context:** For ephemeral agents (non-agent-endpoint model chats), `agent.provider` is set to the endpoint name string, not `EModelEndpoint.anthropic`, so a strict equality check is insufficient.
+
 ## Verification Patterns
 
 Use these patterns when verifying customizations are present:
@@ -278,6 +288,12 @@ grep -n "normalizeServerName" packages/api/src/mcp/registry/MCPServerInspector.t
 grep -n "normalizeServerName" api/server/services/MCP.js
 # Anti-patterns — raw serverName after mcp_delimiter must NOT appear without normalizeServerName:
 grep -n 'mcp_delimiter}${serverName}' packages/api/src/mcp/registry/MCPServerInspector.ts | grep -v normalizeServerName
+
+# 25. Anthropic image encoding for custom endpoints
+grep -n "includes('claude')\|includes('anthropic')" api/server/services/Files/images/encode.js
+# Anti-pattern — Anthropic branch must NOT be below the VisionModes.agents early-return:
+# Verify the 'if (mode === VisionModes.agents)' block appears AFTER the Anthropic else-if block
+grep -n "VisionModes.agents\|includes('claude')" api/server/services/Files/images/encode.js
 
 # 22-24. MCP customizations
 grep -n "startup: config.startup" packages/api/src/mcp/utils.ts

--- a/.github/prompts/merge-upstream.md
+++ b/.github/prompts/merge-upstream.md
@@ -44,6 +44,12 @@ I need to merge LibreChat upstream version [TARGET_VERSION] into Paychex develop
 7. **xlsx Package** (api/package.json, packages/api/package.json)
    - Must use: `"xlsx": "^0.18.5"` (npm registry, not CDN)
 
+8. **Anthropic Image Encoding** (api/server/services/Files/images/encode.js)
+   - Pattern: `effectiveEndpoint.toLowerCase().includes('claude') || effectiveEndpoint.toLowerCase().includes('anthropic')`
+   - This block must appear **before** the `if (mode === VisionModes.agents)` early-return
+   - Converts image parts to Anthropic-native format for custom Claude/Anthropic endpoints
+   - Without this (or if block order is wrong), image uploads to Claude endpoints throw 400 errors
+
 **Requirements:**
 
 ✅ **Must Do:**

--- a/api/server/services/Files/images/encode.js
+++ b/api/server/services/Files/images/encode.js
@@ -215,11 +215,12 @@ async function encodeAndFormat(req, files, params, mode) {
       },
     };
 
+    const endpointLower = typeof effectiveEndpoint === 'string' ? effectiveEndpoint.toLowerCase() : '';
     if (
       effectiveEndpoint &&
       (effectiveEndpoint === EModelEndpoint.anthropic ||
-        effectiveEndpoint.toLowerCase().includes('claude') ||
-        effectiveEndpoint.toLowerCase().includes('anthropic'))
+        endpointLower.includes('claude') ||
+        endpointLower.includes('anthropic'))
     ) {
       imagePart.type = 'image';
       imagePart.source = {

--- a/api/server/services/Files/images/encode.js
+++ b/api/server/services/Files/images/encode.js
@@ -215,7 +215,8 @@ async function encodeAndFormat(req, files, params, mode) {
       },
     };
 
-    const endpointLower = typeof effectiveEndpoint === 'string' ? effectiveEndpoint.toLowerCase() : '';
+    const endpointLower =
+      typeof effectiveEndpoint === 'string' ? effectiveEndpoint.toLowerCase() : '';
     if (
       effectiveEndpoint &&
       (effectiveEndpoint === EModelEndpoint.anthropic ||

--- a/api/server/services/Files/images/encode.js
+++ b/api/server/services/Files/images/encode.js
@@ -215,6 +215,21 @@ async function encodeAndFormat(req, files, params, mode) {
       },
     };
 
+    if (
+      effectiveEndpoint &&
+      (effectiveEndpoint === EModelEndpoint.anthropic ||
+        effectiveEndpoint.toLowerCase().includes('claude') ||
+        effectiveEndpoint.toLowerCase().includes('anthropic'))
+    ) {
+      imagePart.type = 'image';
+      imagePart.source = {
+        type: 'base64',
+        media_type: file.type,
+        data: imageContent,
+      };
+      delete imagePart.image_url;
+    }
+
     if (mode === VisionModes.agents) {
       result.image_urls.push({ ...imagePart });
       result.files.push({ ...fileMetadata });
@@ -233,14 +248,6 @@ async function encodeAndFormat(req, files, params, mode) {
       };
     } else if (effectiveEndpoint && effectiveEndpoint === EModelEndpoint.google) {
       imagePart.image_url = imagePart.image_url.url;
-    } else if (effectiveEndpoint && effectiveEndpoint === EModelEndpoint.anthropic) {
-      imagePart.type = 'image';
-      imagePart.source = {
-        type: 'base64',
-        media_type: file.type,
-        data: imageContent,
-      };
-      delete imagePart.image_url;
     }
 
     result.image_urls.push({ ...imagePart });

--- a/api/server/services/Files/images/encode.spec.js
+++ b/api/server/services/Files/images/encode.spec.js
@@ -20,8 +20,13 @@ jest.mock('librechat-data-provider', () => ({
 }));
 
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
-const { FileSources, VisionModes, ContentTypes, EModelEndpoint, ImageDetail } =
-  require('librechat-data-provider');
+const {
+  FileSources,
+  VisionModes,
+  ContentTypes,
+  EModelEndpoint,
+  ImageDetail,
+} = require('librechat-data-provider');
 const { encodeAndFormat } = require('./encode');
 
 const FAKE_BASE64 = Buffer.from('fake image data').toString('base64');

--- a/api/server/services/Files/images/encode.spec.js
+++ b/api/server/services/Files/images/encode.spec.js
@@ -1,0 +1,170 @@
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@librechat/api', () => ({
+  logAxiosError: jest.fn((args) => args.message),
+  validateImage: jest.fn().mockResolvedValue({ isValid: true }),
+}));
+
+jest.mock('axios');
+
+jest.mock('~/server/services/Files/strategies', () => ({
+  getStrategyFunctions: jest.fn(),
+}));
+
+jest.mock('librechat-data-provider', () => ({
+  ...jest.requireActual('librechat-data-provider'),
+  mergeFileConfig: jest.fn().mockReturnValue({}),
+  getEndpointFileConfig: jest.fn().mockReturnValue({}),
+}));
+
+const { getStrategyFunctions } = require('~/server/services/Files/strategies');
+const { FileSources, VisionModes, ContentTypes, EModelEndpoint, ImageDetail } =
+  require('librechat-data-provider');
+const { encodeAndFormat } = require('./encode');
+
+const FAKE_BASE64 = Buffer.from('fake image data').toString('base64');
+
+function makeImageFile(overrides = {}) {
+  return {
+    file_id: 'file-test-123',
+    filename: 'test.png',
+    filepath: '/uploads/test.png',
+    type: 'image/png',
+    source: FileSources.local,
+    height: 100,
+    width: 100,
+    embedded: false,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe('encodeAndFormat', () => {
+  let mockPrepareImagePayload;
+  const mockReq = { body: { imageDetail: ImageDetail.auto }, config: undefined };
+
+  beforeEach(() => {
+    mockPrepareImagePayload = jest.fn();
+    getStrategyFunctions.mockReturnValue({
+      prepareImagePayload: mockPrepareImagePayload,
+      getDownloadStream: jest.fn(),
+    });
+  });
+
+  describe('returns empty result when given no files', () => {
+    it('returns empty files and image_urls arrays', async () => {
+      const result = await encodeAndFormat(mockReq, [], { endpoint: EModelEndpoint.anthropic });
+      expect(result.files).toHaveLength(0);
+      expect(result.image_urls).toHaveLength(0);
+    });
+  });
+
+  describe('Anthropic image format conversion', () => {
+    let file;
+
+    beforeEach(() => {
+      file = makeImageFile();
+      mockPrepareImagePayload.mockResolvedValue([file, FAKE_BASE64]);
+    });
+
+    it('converts to Anthropic format for native anthropic endpoint in agents mode', async () => {
+      const result = await encodeAndFormat(
+        mockReq,
+        [file],
+        { endpoint: EModelEndpoint.anthropic },
+        VisionModes.agents,
+      );
+
+      expect(result.image_urls).toHaveLength(1);
+      const part = result.image_urls[0];
+      expect(part.type).toBe('image');
+      expect(part.source).toEqual({ type: 'base64', media_type: 'image/png', data: FAKE_BASE64 });
+      expect(part.image_url).toBeUndefined();
+    });
+
+    it('converts to Anthropic format for custom endpoint containing "claude" in agents mode', async () => {
+      const result = await encodeAndFormat(
+        mockReq,
+        [file],
+        { endpoint: 'Claude Sonnet 4.5' },
+        VisionModes.agents,
+      );
+
+      const part = result.image_urls[0];
+      expect(part.type).toBe('image');
+      expect(part.source).toEqual({ type: 'base64', media_type: 'image/png', data: FAKE_BASE64 });
+      expect(part.image_url).toBeUndefined();
+    });
+
+    it('converts to Anthropic format for custom endpoint containing "anthropic" in agents mode', async () => {
+      const result = await encodeAndFormat(
+        mockReq,
+        [file],
+        { endpoint: 'My Anthropic Custom Endpoint' },
+        VisionModes.agents,
+      );
+
+      const part = result.image_urls[0];
+      expect(part.type).toBe('image');
+      expect(part.source).toEqual({ type: 'base64', media_type: 'image/png', data: FAKE_BASE64 });
+      expect(part.image_url).toBeUndefined();
+    });
+
+    it('matching is case-insensitive for custom endpoint names', async () => {
+      const result = await encodeAndFormat(
+        mockReq,
+        [file],
+        { endpoint: 'CLAUDE-3-OPUS' },
+        VisionModes.agents,
+      );
+
+      const part = result.image_urls[0];
+      expect(part.type).toBe('image');
+      expect(part.source).toBeDefined();
+      expect(part.image_url).toBeUndefined();
+    });
+
+    it('does NOT convert to Anthropic format for a non-Anthropic endpoint in agents mode', async () => {
+      const result = await encodeAndFormat(
+        mockReq,
+        [file],
+        { endpoint: 'gpt-4o' },
+        VisionModes.agents,
+      );
+
+      const part = result.image_urls[0];
+      expect(part.type).toBe(ContentTypes.IMAGE_URL);
+      expect(part.image_url).toBeDefined();
+      expect(part.source).toBeUndefined();
+    });
+
+    it('converts to Anthropic format for custom claude endpoint outside agents mode', async () => {
+      const result = await encodeAndFormat(
+        mockReq,
+        [file],
+        { endpoint: 'Claude Sonnet 4.5' },
+        undefined,
+      );
+
+      const part = result.image_urls[0];
+      expect(part.type).toBe('image');
+      expect(part.source).toBeDefined();
+      expect(part.image_url).toBeUndefined();
+    });
+
+    it('uses provider as fallback when endpoint is not provided', async () => {
+      const result = await encodeAndFormat(
+        mockReq,
+        [file],
+        { provider: 'Claude Sonnet 4.5' },
+        VisionModes.agents,
+      );
+
+      const part = result.image_urls[0];
+      expect(part.type).toBe('image');
+      expect(part.source).toBeDefined();
+    });
+  });
+});

--- a/scripts/verify-paychex-customizations.sh
+++ b/scripts/verify-paychex-customizations.sh
@@ -381,6 +381,41 @@ check_pattern \
     "warning"
 
 echo ""
+
+# 16. Anthropic Image Encoding for Custom Endpoints
+echo "16. Anthropic Image Encoding for Custom Endpoints (encode.js)"
+check_pattern \
+    "api/server/services/Files/images/encode.js" \
+    "includes('claude')" \
+    "Custom Claude endpoint detected by name for Anthropic image encoding" \
+    "critical"
+
+check_pattern \
+    "api/server/services/Files/images/encode.js" \
+    "includes('anthropic')" \
+    "Custom Anthropic endpoint detected by name for Anthropic image encoding" \
+    "critical"
+
+# Verify ordering: the Anthropic conversion block must appear BEFORE the VisionModes.agents check.
+# If VisionModes.agents appears before includes('claude'), the Anthropic conversion is dead code for agents.
+ANTHROPIC_LINE=$(grep -n "includes('claude')" api/server/services/Files/images/encode.js 2>/dev/null | head -1 | cut -d: -f1)
+AGENTS_LINE=$(grep -n "mode === VisionModes.agents" api/server/services/Files/images/encode.js 2>/dev/null | head -1 | cut -d: -f1)
+
+if [ -n "$ANTHROPIC_LINE" ] && [ -n "$AGENTS_LINE" ]; then
+    if [ "$ANTHROPIC_LINE" -lt "$AGENTS_LINE" ]; then
+        echo -e "${GREEN}✓ PASS${NC}: Anthropic conversion block appears before VisionModes.agents early-return (line $ANTHROPIC_LINE < $AGENTS_LINE)"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo -e "${RED}✗ FAIL${NC}: Anthropic conversion block is AFTER VisionModes.agents early-return (line $ANTHROPIC_LINE >= $AGENTS_LINE)"
+        echo "         This makes the Anthropic branch dead code for agent-path uploads — images will 400 on Claude endpoints"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+else
+    echo -e "${YELLOW}⚠ WARN${NC}: Could not determine line ordering for Anthropic block vs VisionModes.agents"
+    WARN_COUNT=$((WARN_COUNT + 1))
+fi
+
+echo ""
 echo "======================================"
 echo "Verification Summary"
 echo "======================================"


### PR DESCRIPTION
- Fixes 400 "Input tag 'image_url'..." error in Claude models by converting OpenAI format to Anthropic `{ type: 'image', source: { type: 'base64', ... } }`
- Applies to native `anthropic` and custom endpoints containing "claude"/"anthropic"
- Moves conversion before `VisionModes.agents` early-return so agent uploads are handled
- Verified uploads succeed on native/custom Claude; Google formatting unaffected
