### PR TITLE
fix: handle RAG context 404 gracefully in createContextHandlers

### DIFF
--- a/api/app/clients/prompts/createContextHandlers.js
+++ b/api/app/clients/prompts/createContextHandlers.js
@@ -65,8 +65,38 @@ function createContextHandlers(req, userMessageContent) {
         return '';
       }
 
-      const oneFile = processedFiles.length === 1;
-      const header = `The user has attached ${oneFile ? 'a' : processedFiles.length} file${
+      const settledQueries = await Promise.allSettled(queryPromises);
+
+      const successfulResults = [];
+      const successfulFiles = [];
+      for (let i = 0; i < settledQueries.length; i++) {
+        const result = settledQueries[i];
+        const file = processedFiles[i];
+        if (result.status === 'fulfilled') {
+          successfulResults.push(result.value);
+          successfulFiles.push(file);
+        } else {
+          const statusCode = result.reason?.response?.status;
+          if (statusCode === 404) {
+            logger.warn(
+              `File context not found for "${file.filename}" (file_id: ${file.file_id}). ` +
+                'The file may not have been indexed successfully.',
+            );
+          } else {
+            logger.error(
+              `Error fetching context for file "${file.filename}":`,
+              result.reason,
+            );
+          }
+        }
+      }
+
+      if (!successfulResults.length) {
+        return '';
+      }
+
+      const oneFile = successfulFiles.length === 1;
+      const header = `The user has attached ${oneFile ? 'a' : successfulFiles.length} file${
         !oneFile ? 's' : ''
       } to the conversation:`;
 
@@ -75,7 +105,7 @@ function createContextHandlers(req, userMessageContent) {
           ? ''
           : `
       <files>`
-      }${processedFiles
+      }${successfulFiles
         .map(
           (file) => `
               <file>
@@ -90,14 +120,12 @@ function createContextHandlers(req, userMessageContent) {
         </files>`
       }`;
 
-      const resolvedQueries = await Promise.all(queryPromises);
-
       const context =
-        resolvedQueries.length === 0
+        successfulResults.length === 0
           ? '\n\tThe semantic search did not return any results.'
-          : resolvedQueries
+          : successfulResults
               .map((queryResult, index) => {
-                const file = processedFiles[index];
+                const file = successfulFiles[index];
                 let contextItems = queryResult.data;
 
                 const generateContext = (currentContext) =>

--- a/api/app/clients/prompts/createContextHandlers.js
+++ b/api/app/clients/prompts/createContextHandlers.js
@@ -83,10 +83,7 @@ function createContextHandlers(req, userMessageContent) {
                 'The file may not have been indexed successfully.',
             );
           } else {
-            logger.error(
-              `Error fetching context for file "${file.filename}":`,
-              result.reason,
-            );
+            logger.error(`Error fetching context for file "${file.filename}":`, result.reason);
           }
         }
       }


### PR DESCRIPTION
fix: handle RAG context 404 gracefully in createContextHandlers
When RAG_USE_FULL_CONTEXT is true and a file has not been successfully
indexed (e.g. due to empty embeddings from an image-only PDF), the RAG
API returns 404 from GET /documents/{id}/context. The previous code used
Promise.all which caused the first 404 to immediately reject and throw,
crashing the entire generation and leaving the input field disabled
until the page was refreshed.

Replace Promise.all with Promise.allSettled so that individual file
failures are isolated. Files that return 404 are logged as a warning
and skipped; all other successfully retrieved files still contribute
context to the prompt. Any non-404 errors are still logged as errors.

Made-with: Cursor