### PR TITLE
feature/AIA-2203- Add Prompt Catalog Insert to LibreChat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ MONGO_AUTO_CREATE=
 DOMAIN_CLIENT=http://localhost:3080
 DOMAIN_SERVER=http://localhost:3080
 
+# Prompt Catalog import (Paychex)
+# PROMPT_CATALOG_API_URL=
+
 NO_INDEX=true
 # Use the address that is at most n number of hops away from the Express application.
 # req.socket.remoteAddress is the first hop, and the rest are looked for in the X-Forwarded-For header from right to left.

--- a/.github/agents/upstream-merge.agent.md
+++ b/.github/agents/upstream-merge.agent.md
@@ -77,6 +77,9 @@ For each conflicted file, determine its risk level:
 - `api/server/services/start/tools.js` — sanitizeSchemaMetadata  
 - `api/server/services/MCP.js` — Gemini custom endpoint detection
 - `api/server/services/Files/images/encode.js` — Anthropic image encoding; `includes('claude')||includes('anthropic')` block must appear before `VisionModes.agents` early-return
+- `api/server/routes/prompthub.js` — Prompt Catalog deep-link route; preserve `POST /api/prompthub/resolve-insert`
+- `packages/api/src/promptCatalog/handlers.ts`, `packages/api/src/index.ts` — Prompt Catalog resolver export loaded by `@librechat/api`
+- `client/src/hooks/Input/useQueryParams.ts`, `client/src/routes/ChatRoute.tsx` — `promptCatalogId` handling, timeout/toast behavior, and query-param exclusion
 - `Dockerfile` — && error handling
 - `**/package.json` — xlsx must use npm registry
 
@@ -186,6 +189,21 @@ grep "@librechat/api" api/server/services/Endpoints/index.js
 
 Should see: `initializeCustom, initializeOpenAI, initializeAnthropic, etc.`
 
+**Prompt Catalog deep-link integration:**
+Verify route mounts, resolver export, and client query-param handling:
+```bash
+grep -n "/api/prompthub" api/server/index.js api/server/experimental.js api/server/routes/index.js
+grep -n "createPromptHubResolveInsertHandler" api/server/routes/prompthub.js packages/api/src/index.ts packages/api/src/promptCatalog/handlers.ts
+grep -n "PROMPT_CATALOG_API_URL" .env.example api/server/routes/prompthub.js packages/api/src/promptCatalog/handlers.ts
+grep -n "promptCatalogId\|prompt_catalog_id" client/src/hooks/Input/useQueryParams.ts client/src/routes/ChatRoute.tsx
+grep -n "com_ui_prompt_catalog_insert_error" client/src/hooks/Input/useQueryParams.ts client/src/locales/en/translation.json
+```
+
+If the backend crashes with `createPromptHubResolveInsertHandler is not a function`, rebuild the compiled package that `@librechat/api` exports:
+```bash
+npm run build:api
+```
+
 ### Step 11 — Build and test
 
 ```bash
@@ -224,6 +242,7 @@ Critical customizations verified:
 - filterCrossProviderToolCalls (BaseClient.js)
 - sanitizeSchemaMetadata (tools.js)
 - Gemini custom endpoint detection (MCP.js)
+- Prompt Catalog deep-link integration (`/api/prompthub/resolve-insert`, `promptCatalogId`, `PROMPT_CATALOG_API_URL`)
 - Dockerfile error handling
 - All other Paychex-specific features preserved
 
@@ -265,6 +284,7 @@ Also suggest:
 ❌ **Don't** skip verification steps  
 ❌ **Don't** commit without building and testing  
 ❌ **Don't** forget to fix broken import paths after file moves  
+❌ **Don't** drop the Prompt Catalog route mount, `promptCatalogId` flow, or `@librechat/api` export during refactors  
 
 ✅ **Do** check git history before resolving conflicts  
 ✅ **Do** verify customizations are present after each major step  

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,6 +74,12 @@ When working with code, always preserve these critical Paychex customizations:
 - **Purpose:** Converts image parts to Anthropic-native format (`type: 'image'`, `source: { base64 }`) for both the native `anthropic` endpoint and custom endpoints whose name contains "claude" or "anthropic". The conversion block is placed **before** the `VisionModes.agents` early-return so agent-path uploads are also converted correctly.
 - **Critical:** YES - Image uploads to any Claude/Anthropic endpoint throw a 400 error without this
 
+### 9. Prompt Catalog Insert Deep Link Integration
+- **Files:** `api/server/routes/prompthub.js`, `packages/api/src/promptCatalog/handlers.ts`, `packages/api/src/index.ts`, `client/src/hooks/Input/useQueryParams.ts`, `client/src/routes/ChatRoute.tsx`
+- **Patterns:** `POST /api/prompthub/resolve-insert`, `promptCatalogId`, `PROMPT_CATALOG_API_URL`, `com_ui_prompt_catalog_insert_error`
+- **Purpose:** Lets AI Hub open LibreChat with only a Prompt Catalog ID. LibreChat must resolve the stored prompt server-side, forward authenticated user identity headers to Prompt Catalog, exclude insert params from preset merging, and show a user-visible toast if resolution fails or times out.
+- **Critical:** NO - App functions without it, but AI Hub Prompt Catalog deep links silently break or hang without it
+
 ## Upstream Merge Process
 
 When merging upstream LibreChat releases:
@@ -91,6 +97,10 @@ When merging upstream LibreChat releases:
 - `api/server/services/start/tools.js` — Contains `sanitizeSchemaMetadata`
 - `api/server/services/MCP.js` — Custom Gemini endpoint detection
 - `api/server/services/Files/images/encode.js` — Anthropic image encoding; block order relative to `VisionModes.agents` is critical
+- `api/server/routes/prompthub.js` — Prompt Catalog resolve-insert route wiring
+- `packages/api/src/promptCatalog/handlers.ts` and `packages/api/src/index.ts` — Prompt Catalog resolver export loaded by `@librechat/api`
+- `client/src/hooks/Input/useQueryParams.ts` — `promptCatalogId` resolution, timeout, and toast behavior
+- `client/src/routes/ChatRoute.tsx` — Excludes Prompt Catalog query params from preset merging
 - `Dockerfile` — Build error handling
 - `package.json` files — Dependency versions (use npm registry for xlsx, not CDN)
 
@@ -107,6 +117,7 @@ When merging upstream LibreChat releases:
 | `npm run smart-reinstall` | Install deps (if lockfile changed) + build via Turborepo |
 | `npm run backend` | Start the backend server |
 | `npm run backend:dev` | Start backend with file watching (development) |
+| `npm run build:api` | Rebuild compiled `@librechat/api` after changes in `packages/api/src` |
 | `npm run frontend:dev` | Start frontend dev server with HMR (port 3090) |
 | `npm run build` | Build all compiled code via Turborepo |
 | `scripts/verify-paychex-customizations.sh` | Verify all Paychex customizations are present |

--- a/.github/instructions/merge-process.instructions.md
+++ b/.github/instructions/merge-process.instructions.md
@@ -23,6 +23,7 @@ These customizations MUST be preserved during upstream merges. Verify after ever
 | Dockerfile Error Handling | `Dockerfile` | `&&` operators (not `;`) | Prevents masked build failures - critical for CI/CD |
 | xlsx Package | `api/package.json`, `packages/api/package.json` | `"xlsx": "^0.18.5"` (npm registry, not CDN) | CDN returns 403 errors - builds fail without this |
 | Anthropic Image Encoding | `api/server/services/Files/images/encode.js` | `includes('claude') \|\| includes('anthropic')` (before `VisionModes.agents` block) | Custom Claude/Anthropic endpoints get 400 errors on image uploads without this; block order matters |
+| Prompt Catalog Insert Integration | `api/server/routes/prompthub.js`, `packages/api/src/promptCatalog/handlers.ts`, `client/src/hooks/Input/useQueryParams.ts`, `client/src/routes/ChatRoute.tsx` | `/api/prompthub/resolve-insert`, `promptCatalogId`, `PROMPT_CATALOG_API_URL`, `com_ui_prompt_catalog_insert_error` | Preserves AI Hub Prompt Catalog → LibreChat deep links with server-side resolution, query-param exclusion, visible failures, and no infinite polling |
 
 ## Merge Conflict Decision Matrix
 
@@ -57,6 +58,10 @@ Apply this matrix when resolving each conflict:
 - `api/server/services/start/tools.js`
 - `api/server/services/MCP.js`
 - `api/server/services/Files/images/encode.js`
+- `api/server/routes/prompthub.js`
+- `packages/api/src/promptCatalog/**/*.ts`
+- `client/src/hooks/Input/useQueryParams.ts`
+- `client/src/routes/ChatRoute.tsx`
 - `Dockerfile`
 - `api/package.json`
 - `packages/api/package.json`
@@ -194,6 +199,13 @@ grep '"xlsx"' api/package.json packages/api/package.json
 # Check Dockerfile error handling
 grep -A1 "npm run frontend" Dockerfile | grep "&&"
 # Should use && (not ;)
+
+# Check Prompt Catalog deep-link integration
+grep -n "/api/prompthub" api/server/index.js api/server/experimental.js api/server/routes/index.js
+grep -n "createPromptHubResolveInsertHandler" api/server/routes/prompthub.js packages/api/src/index.ts packages/api/src/promptCatalog/handlers.ts
+grep -n "PROMPT_CATALOG_API_URL" .env.example api/server/routes/prompthub.js packages/api/src/promptCatalog/handlers.ts
+grep -n "promptCatalogId\|prompt_catalog_id" client/src/hooks/Input/useQueryParams.ts client/src/routes/ChatRoute.tsx
+grep -n "com_ui_prompt_catalog_insert_error" client/src/hooks/Input/useQueryParams.ts client/src/locales/en/translation.json
 ```
 
 ## Post-Merge Validation
@@ -216,6 +228,7 @@ Before considering merge complete:
 | Consolidating tool definitions | Paychex sanitization may be lost | Manually re-apply in new location |
 | TypeScript migration | Type conflicts | Use types from `packages/data-provider` |
 | Component prop changes | Paychex custom props may break | Adapt to new prop structure |
+| Query-param handling refactors in `ChatRoute` / `useQueryParams` | Prompt Catalog deep links regress | Preserve `promptCatalogId` exclusion, same-origin `/api/prompthub/resolve-insert` flow, and timeout/toast failure handling |
 
 ## Troubleshooting Quick Reference
 
@@ -227,6 +240,8 @@ Before considering merge complete:
 | xlsx 403 error | Change to `"xlsx": "^0.18.5"` in package.json files |
 | Dockerfile build masks errors | Change `;` to `&&` in command chains |
 | TypeScript duplicate identifier | Check `packages/data-provider/src/types/` for existing definition |
+| `createPromptHubResolveInsertHandler is not a function` at startup | Rebuild `@librechat/api` with `npm run build:api`; JS routes load the compiled package from `packages/api/dist` |
+| AI Hub deep link opens blank LibreChat chat | Verify `/api/prompthub` mounts, `PROMPT_CATALOG_API_URL`, `promptCatalogId` handling, and the Prompt Catalog error toast key |
 
 ## Reference Documentation Paths
 

--- a/.github/instructions/paychex-customizations.instructions.md
+++ b/.github/instructions/paychex-customizations.instructions.md
@@ -252,6 +252,25 @@ Complete catalog of Paychex-specific modifications to LibreChat.
 - **Added:** April 2026 bugfix
 - **Context:** For ephemeral agents (non-agent-endpoint model chats), `agent.provider` is set to the endpoint name string, not `EModelEndpoint.anthropic`, so a strict equality check is insufficient.
 
+**26. Prompt Catalog Insert Deep-Link Integration**
+- **Files:** `api/server/index.js`, `api/server/experimental.js`, `api/server/routes/index.js`, `api/server/routes/prompthub.js`, `packages/api/src/promptCatalog/handlers.ts`, `packages/api/src/promptCatalog/index.ts`, `packages/api/src/index.ts`, `client/src/hooks/Input/useQueryParams.ts`, `client/src/routes/ChatRoute.tsx`, `.env.example`
+- **Patterns (must be present):**
+  - `/api/prompthub` mounted in both `api/server/index.js` and `api/server/experimental.js`
+  - `POST /api/prompthub/resolve-insert`
+  - `createPromptHubResolveInsertHandler`
+  - `PROMPT_CATALOG_API_URL`
+  - `promptCatalogId` and `prompt_catalog_id`
+  - `x-forwarded-user-email`, `x-forwarded-user-name`
+  - `com_ui_prompt_catalog_insert_error`
+- **Purpose:** Supports AI Hub Prompt Catalog deep links that open LibreChat with only a Prompt Catalog ID. LibreChat resolves the stored prompt server-side through its own backend, forwards authenticated user identity headers to Prompt Catalog, injects the resolved text into the composer, excludes insert params from model/preset query parsing, and shows a toast if resolution fails or times out.
+- **Anti-patterns (must be absent):**
+  - direct browser fetch from LibreChat client to Prompt Catalog
+  - full prompt text handoff in the LibreChat URL for this feature
+- **Criticality:** WARNING — App functions without it, but AI Hub → LibreChat Prompt Catalog deep links silently break or hang without these pieces
+- **Added:** April 2026
+- **Context:** This is intentionally simpler than `feature/prompthub-integration`; preserve the ID-based same-origin flow and do not replace it with ticket/callback/export behavior unless scope changes.
+- **Build note:** `packages/api/src/promptCatalog/*.ts` compiles into `@librechat/api`, which the JS route layer loads from `packages/api/dist`. Any change here requires `npm run build:api` before restarting the backend, or use the updated `npm run backend:dev` script which rebuilds the compiled packages first.
+
 ## Verification Patterns
 
 Use these patterns when verifying customizations are present:
@@ -295,6 +314,14 @@ grep -n "includes('claude')\|includes('anthropic')" api/server/services/Files/im
 # Verify the 'if (mode === VisionModes.agents)' block appears AFTER the Anthropic else-if block
 grep -n "VisionModes.agents\|includes('claude')" api/server/services/Files/images/encode.js
 
+# 26. Prompt Catalog insert deep-link integration
+grep -n "/api/prompthub" api/server/index.js api/server/experimental.js api/server/routes/index.js
+grep -n "createPromptHubResolveInsertHandler" api/server/routes/prompthub.js packages/api/src/index.ts packages/api/src/promptCatalog/handlers.ts
+grep -n "PROMPT_CATALOG_API_URL" .env.example api/server/routes/prompthub.js packages/api/src/promptCatalog/handlers.ts
+grep -n "x-forwarded-user-email\|x-forwarded-user-name" packages/api/src/promptCatalog/handlers.ts
+grep -n "promptCatalogId\|prompt_catalog_id" client/src/hooks/Input/useQueryParams.ts client/src/routes/ChatRoute.tsx
+grep -n "com_ui_prompt_catalog_insert_error" client/src/hooks/Input/useQueryParams.ts client/src/locales/en/translation.json
+
 # 22-24. MCP customizations
 grep -n "startup: config.startup" packages/api/src/mcp/utils.ts
 grep -n "s.config.startup === true" client/src/hooks/MCP/useMCPServerManager.ts
@@ -328,6 +355,7 @@ When adding new Paychex customizations:
 - Code organization improvements
 - Documentation
 - Model preference guard
+- Prompt Catalog insert integration
 
 Use this as reference when deciding whether to preserve customization during upstream merges.
 

--- a/.github/prompts/merge-upstream.md
+++ b/.github/prompts/merge-upstream.md
@@ -50,6 +50,11 @@ I need to merge LibreChat upstream version [TARGET_VERSION] into Paychex develop
    - Converts image parts to Anthropic-native format for custom Claude/Anthropic endpoints
    - Without this (or if block order is wrong), image uploads to Claude endpoints throw 400 errors
 
+9. **Prompt Catalog Insert Deep-Link Integration** (`api/server/routes/prompthub.js`, `packages/api/src/promptCatalog/handlers.ts`, `client/src/hooks/Input/useQueryParams.ts`, `client/src/routes/ChatRoute.tsx`)
+   - Patterns: `/api/prompthub/resolve-insert`, `promptCatalogId`, `PROMPT_CATALOG_API_URL`, `com_ui_prompt_catalog_insert_error`
+   - Required for AI Hub Prompt Catalog deep links to open LibreChat with server-side resolved prompt text
+   - Preserve the route mount, `@librechat/api` export, query-param exclusion in `ChatRoute`, and failure timeout/toast behavior
+
 **Requirements:**
 
 ✅ **Must Do:**
@@ -58,6 +63,7 @@ I need to merge LibreChat upstream version [TARGET_VERSION] into Paychex develop
 - Preserve ALL customizations listed above
 - Verify after resolution: `./scripts/verify-paychex-customizations.sh`
 - Build and test before committing
+- Rebuild `@librechat/api` (`npm run build:api`) if merged files under `packages/api/src` changed
 - Ask clarifying questions when uncertain
 
 ❌ **Must Not:**

--- a/.github/workflows/cxone-github-action.yml
+++ b/.github/workflows/cxone-github-action.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkmarx One CLI Action
-        uses: checkmarx/ast-github-action@2.3.33 #Github Action version
+        uses: checkmarx/ast-github-action@2.3.36 #Github Action version
         with:
           project_name: pltsvc-librechat-pyx
           cx_tenant: paychex_prod

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -308,6 +308,7 @@ if (cluster.isMaster) {
     app.use('/api/convos', routes.convos);
     app.use('/api/presets', routes.presets);
     app.use('/api/prompts', routes.prompts);
+    app.use('/api/prompthub', routes.prompthub);
     app.use('/api/categories', routes.categories);
     app.use('/api/endpoints', routes.endpoints);
     app.use('/api/balance', routes.balance);

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -147,6 +147,7 @@ const startServer = async () => {
   app.use('/api/convos', routes.convos);
   app.use('/api/presets', routes.presets);
   app.use('/api/prompts', routes.prompts);
+  app.use('/api/prompthub', routes.prompthub);
   app.use('/api/categories', routes.categories);
   app.use('/api/endpoints', routes.endpoints);
   app.use('/api/balance', routes.balance);

--- a/api/server/routes/index.js
+++ b/api/server/routes/index.js
@@ -4,6 +4,7 @@ const categories = require('./categories');
 const adminAuth = require('./admin/auth');
 const endpoints = require('./endpoints');
 const staticRoute = require('./static');
+const prompthub = require('./prompthub');
 const messages = require('./messages');
 const memories = require('./memories');
 const presets = require('./presets');
@@ -46,6 +47,7 @@ module.exports = {
   config,
   models,
   prompts,
+  prompthub,
   actions,
   presets,
   balance,

--- a/api/server/routes/prompthub.js
+++ b/api/server/routes/prompthub.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const { createPromptHubResolveInsertHandler } = require('@librechat/api');
+const { requireJwtAuth } = require('~/server/middleware');
+
+const router = express.Router();
+
+const promptHubResolveInsertHandler = createPromptHubResolveInsertHandler({
+  getPromptCatalogApiUrl: () => process.env.PROMPT_CATALOG_API_URL,
+});
+
+router.post('/resolve-insert', requireJwtAuth, promptHubResolveInsertHandler);
+
+module.exports = router;

--- a/client/src/hooks/Input/useQueryParams.spec.ts
+++ b/client/src/hooks/Input/useQueryParams.spec.ts
@@ -18,13 +18,19 @@ jest.mock('~/store', () => ({
 }));
 
 import { renderHook, act } from '@testing-library/react';
+import { useToastContext } from '@librechat/client';
 import { useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 import useQueryParams from './useQueryParams';
+import {
+  useAuthContext,
+  useAgentsMap,
+  useDefaultConvo,
+  useLocalize,
+  useSubmitMessage,
+} from '~/hooks';
 import { useChatContext, useChatFormContext } from '~/Providers';
-import useSubmitMessage from '~/hooks/Messages/useSubmitMessage';
-import useDefaultConvo from '~/hooks/Conversations/useDefaultConvo';
 import store from '~/store';
 
 // Other mocks
@@ -37,32 +43,21 @@ jest.mock('@tanstack/react-query', () => ({
   useQuery: jest.fn(),
 }));
 
+jest.mock('@librechat/client', () => ({
+  useToastContext: jest.fn(),
+}));
+
 jest.mock('~/Providers', () => ({
   useChatContext: jest.fn(),
   useChatFormContext: jest.fn(),
 }));
 
-jest.mock('~/hooks/Messages/useSubmitMessage', () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
-
-jest.mock('~/hooks/Conversations/useDefaultConvo', () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
-
-jest.mock('~/hooks/AuthContext', () => ({
+jest.mock('~/hooks', () => ({
   useAuthContext: jest.fn(),
-}));
-
-jest.mock('~/hooks/Agents/useAgentsMap', () => ({
-  __esModule: true,
-  default: jest.fn(() => ({})),
-}));
-jest.mock('~/hooks/Agents/useAgentDefaultPermissionLevel', () => ({
-  __esModule: true,
-  default: jest.fn(() => ({})),
+  useAgentsMap: jest.fn(() => ({})),
+  useDefaultConvo: jest.fn(),
+  useLocalize: jest.fn(),
+  useSubmitMessage: jest.fn(),
 }));
 
 jest.mock('~/utils', () => {
@@ -124,6 +119,7 @@ describe('useQueryParams', () => {
   // Setup common mocks before each test
   beforeEach(() => {
     jest.useFakeTimers();
+    global.fetch = jest.fn();
 
     // Reset mock for window.history.replaceState
     jest.spyOn(window.history, 'replaceState').mockClear();
@@ -181,11 +177,15 @@ describe('useQueryParams', () => {
     const mockGetDefaultConversation = jest.fn().mockReturnValue({});
     (useDefaultConvo as jest.Mock).mockReturnValue(mockGetDefaultConversation);
 
-    // Mock useAuthContext
-    const { useAuthContext } = jest.requireMock('~/hooks/AuthContext');
     (useAuthContext as jest.Mock).mockReturnValue({
       user: { id: 'test-user-id' },
+      token: 'test-token',
       isAuthenticated: true,
+    });
+    (useAgentsMap as jest.Mock).mockReturnValue({});
+    (useLocalize as jest.Mock).mockReturnValue((key: string) => key);
+    (useToastContext as jest.Mock).mockReturnValue({
+      showToast: jest.fn(),
     });
   });
 
@@ -303,6 +303,188 @@ describe('useQueryParams', () => {
     );
     expect(mockHandleSubmit).toHaveBeenCalled();
     expect(mockSubmitMessage).toHaveBeenCalled();
+  });
+
+  it('should resolve PromptHub-style Prompt Catalog inserts before filling the textarea', async () => {
+    const mockSetValue = jest.fn();
+    const mockSetSearchParams = jest.fn();
+    const mockTextAreaRef = {
+      current: {
+        focus: jest.fn(),
+        setSelectionRange: jest.fn(),
+      } as unknown as HTMLTextAreaElement,
+    };
+
+    (useChatFormContext as jest.Mock).mockReturnValue({
+      setValue: mockSetValue,
+      getValues: jest.fn().mockReturnValue(''),
+      handleSubmit: jest.fn((callback) => () => callback({ text: 'test message' })),
+    });
+
+    (useSearchParams as jest.Mock).mockReturnValue([
+      new URLSearchParams({ promptCatalogId: '123' }),
+      mockSetSearchParams,
+    ]);
+
+    (useQueryClient as jest.Mock).mockReturnValue({
+      getQueryData: jest.fn().mockImplementation((key) => {
+        const k = Array.isArray(key) ? key[0] : key;
+        if (k === 'startupConfig') {
+          return { modelSpecs: { list: [] } };
+        }
+        if (k === 'endpoints') {
+          return {};
+        }
+        return null;
+      }),
+    });
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ content: 'Prompt from catalog' }),
+    });
+
+    renderHook(() => useQueryParams({ textAreaRef: mockTextAreaRef }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/prompthub/resolve-insert', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+      },
+      body: JSON.stringify({ promptCatalogId: '123' }),
+    });
+    expect(mockSetValue).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+
+    expect(mockSetValue).toHaveBeenCalledWith(
+      'text',
+      'Prompt from catalog',
+      expect.objectContaining({ shouldValidate: true }),
+    );
+    expect(mockSetSearchParams).toHaveBeenCalledWith(
+      expect.any(URLSearchParams),
+      expect.objectContaining({ replace: true }),
+    );
+  });
+
+  it('should show a toast when resolving a Prompt Catalog insert fails', async () => {
+    const mockSetSearchParams = jest.fn();
+    const mockTextAreaRef = {
+      current: {
+        focus: jest.fn(),
+        setSelectionRange: jest.fn(),
+      } as unknown as HTMLTextAreaElement,
+    };
+    const showToast = jest.fn();
+
+    (useToastContext as jest.Mock).mockReturnValue({ showToast });
+    (useSearchParams as jest.Mock).mockReturnValue([
+      new URLSearchParams({ promptCatalogId: '123' }),
+      mockSetSearchParams,
+    ]);
+
+    (useQueryClient as jest.Mock).mockReturnValue({
+      getQueryData: jest.fn().mockImplementation((key) => {
+        const k = Array.isArray(key) ? key[0] : key;
+        if (k === 'startupConfig') {
+          return { modelSpecs: { list: [] } };
+        }
+        if (k === 'endpoints') {
+          return {};
+        }
+        return null;
+      }),
+    });
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: jest.fn().mockResolvedValue({ message: 'Prompt not found' }),
+    });
+
+    renderHook(() => useQueryParams({ textAreaRef: mockTextAreaRef }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+
+    expect(showToast).toHaveBeenCalledWith({
+      message: 'com_ui_prompt_catalog_insert_error',
+      severity: 'error',
+    });
+    expect(mockSetSearchParams).toHaveBeenCalledWith(
+      expect.any(URLSearchParams),
+      expect.objectContaining({ replace: true }),
+    );
+  });
+
+  it('should time out and show a toast when auth is ready but token never becomes available', async () => {
+    const mockSetSearchParams = jest.fn();
+    const mockTextAreaRef = {
+      current: {
+        focus: jest.fn(),
+        setSelectionRange: jest.fn(),
+      } as unknown as HTMLTextAreaElement,
+    };
+    const showToast = jest.fn();
+
+    (useToastContext as jest.Mock).mockReturnValue({ showToast });
+    (useAuthContext as jest.Mock).mockReturnValue({
+      user: { id: 'test-user-id' },
+      token: '',
+      isAuthenticated: true,
+    });
+    (useSearchParams as jest.Mock).mockReturnValue([
+      new URLSearchParams({ promptCatalogId: '123' }),
+      mockSetSearchParams,
+    ]);
+
+    (useQueryClient as jest.Mock).mockReturnValue({
+      getQueryData: jest.fn().mockImplementation((key) => {
+        const k = Array.isArray(key) ? key[0] : key;
+        if (k === 'startupConfig') {
+          return { modelSpecs: { list: [] } };
+        }
+        if (k === 'endpoints') {
+          return {};
+        }
+        return null;
+      }),
+    });
+
+    renderHook(() => useQueryParams({ textAreaRef: mockTextAreaRef }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(5100);
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith({
+      message: 'com_ui_prompt_catalog_insert_error',
+      severity: 'error',
+    });
+    expect(mockSetSearchParams).toHaveBeenCalledWith(
+      expect.any(URLSearchParams),
+      expect.objectContaining({ replace: true }),
+    );
   });
 
   it('should defer submission when settings need to be applied first', () => {

--- a/client/src/hooks/Input/useQueryParams.ts
+++ b/client/src/hooks/Input/useQueryParams.ts
@@ -1,4 +1,5 @@
 import { useEffect, useCallback, useRef } from 'react';
+import { useToastContext } from '@librechat/client';
 import { useRecoilValue } from 'recoil';
 import { useSearchParams } from 'react-router-dom';
 import { QueryClient, useQueryClient } from '@tanstack/react-query';
@@ -18,10 +19,57 @@ import {
   getConvoSwitchLogic,
   logger,
 } from '~/utils';
-import { useAuthContext, useAgentsMap, useDefaultConvo, useSubmitMessage } from '~/hooks';
+import {
+  useAuthContext,
+  useAgentsMap,
+  useDefaultConvo,
+  useSubmitMessage,
+  useLocalize,
+} from '~/hooks';
 import { useChatContext, useChatFormContext } from '~/Providers';
+import { NotificationSeverity } from '~/common';
 import { useGetAgentByIdQuery } from '~/data-provider';
 import store from '~/store';
+
+const PROMPT_CATALOG_ID_QUERY_PARAM = 'promptCatalogId';
+const LEGACY_PROMPT_CATALOG_ID_QUERY_PARAM = 'prompt_catalog_id';
+
+async function resolvePromptCatalogInsert(promptCatalogId: string, token: string): Promise<string> {
+  const response = await fetch('/api/prompthub/resolve-insert', {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ promptCatalogId }),
+  });
+
+  let data: { prompt?: string; content?: string; message?: string } | null = null;
+  try {
+    data = await response.json();
+  } catch {
+    data = null;
+  }
+
+  if (!response.ok) {
+    throw new Error(data?.message || 'Failed to resolve Prompt Catalog insert');
+  }
+
+  const promptText =
+    typeof data?.content === 'string'
+      ? data.content
+      : typeof data?.prompt === 'string'
+        ? data.prompt
+        : null;
+
+  if (promptText == null) {
+    throw new Error('PromptHub resolve response did not include prompt text');
+  }
+
+  return promptText;
+}
 
 const injectAgentIntoAgentsMap = (queryClient: QueryClient, agent: any) => {
   const editCacheKey = [QueryKeys.agents, { requiredPermission: PermissionBits.EDIT }];
@@ -56,6 +104,9 @@ export default function useQueryParams({
   const settingsAppliedRef = useRef(false);
   const submissionHandledRef = useRef(false);
   const promptTextRef = useRef<string | null>(null);
+  const promptCatalogTextRef = useRef<string | null>(null);
+  const promptCatalogFetchStartedRef = useRef(false);
+  const promptCatalogFailedRef = useRef(false);
   const validSettingsRef = useRef<TPreset | null>(null);
   const settingsTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -65,6 +116,9 @@ export default function useQueryParams({
   const modularChat = useRecoilValue(store.modularChat);
   const availableTools = useRecoilValue(store.availableTools);
   const { submitMessage } = useSubmitMessage();
+  const { token, isAuthenticated } = useAuthContext();
+  const { showToast } = useToastContext();
+  const localize = useLocalize();
 
   const queryClient = useQueryClient();
   const { conversation, newConversation } = useChatContext();
@@ -233,22 +287,48 @@ export default function useQueryParams({
         queryParams[key] = value;
       });
 
+      const promptCatalogId =
+        queryParams[PROMPT_CATALOG_ID_QUERY_PARAM] ||
+        queryParams[LEGACY_PROMPT_CATALOG_ID_QUERY_PARAM] ||
+        '';
       // Support both 'prompt' and 'q' as query parameters, with 'prompt' taking precedence
-      const decodedPrompt = queryParams.prompt || queryParams.q || '';
+      const decodedPrompt = promptCatalogId
+        ? promptCatalogTextRef.current || ''
+        : queryParams.prompt || queryParams.q || '';
       const shouldAutoSubmit = queryParams.submit?.toLowerCase() === 'true';
+      delete queryParams[PROMPT_CATALOG_ID_QUERY_PARAM];
+      delete queryParams[LEGACY_PROMPT_CATALOG_ID_QUERY_PARAM];
       delete queryParams.prompt;
       delete queryParams.q;
       delete queryParams.submit;
       const validSettings = processValidSettings(queryParams);
 
-      return { decodedPrompt, validSettings, shouldAutoSubmit };
+      return { decodedPrompt, promptCatalogId, validSettings, shouldAutoSubmit };
+    };
+
+    const handlePromptCatalogFailure = (reason: string) => {
+      processedRef.current = true;
+      logger.warn('conversation', reason);
+      showToast({
+        message: localize('com_ui_prompt_catalog_insert_error'),
+        severity: NotificationSeverity.ERROR,
+      });
+      setSearchParams(new URLSearchParams(), { replace: true });
     };
 
     const intervalId = setInterval(() => {
+      const { decodedPrompt, promptCatalogId, validSettings, shouldAutoSubmit } =
+        processQueryParams();
+
       if (processedRef.current || attemptsRef.current >= maxAttempts) {
         clearInterval(intervalId);
         if (attemptsRef.current >= maxAttempts) {
           console.warn('Max attempts reached, failed to process parameters');
+          if (promptCatalogId && promptCatalogTextRef.current == null) {
+            handlePromptCatalogFailure(
+              'PromptHub insert timed out before Prompt Catalog prompt could be resolved',
+            );
+          }
         }
         return;
       }
@@ -262,9 +342,33 @@ export default function useQueryParams({
       if (!startupConfig) {
         return;
       }
-
-      const { decodedPrompt, validSettings, shouldAutoSubmit } = processQueryParams();
       const hasSettings = Object.keys(validSettings).length > 0;
+
+      if (promptCatalogId && promptCatalogTextRef.current == null) {
+        if (!isAuthenticated || token == null || token === '') {
+          return;
+        }
+
+        attemptsRef.current = Math.max(0, attemptsRef.current - 1);
+
+        if (!promptCatalogFetchStartedRef.current) {
+          promptCatalogFetchStartedRef.current = true;
+          void resolvePromptCatalogInsert(promptCatalogId, token)
+            .then((prompt) => {
+              promptCatalogTextRef.current = prompt;
+            })
+            .catch((error) => {
+              promptCatalogFailedRef.current = true;
+              logger.error('Failed to resolve PromptHub insert:', error);
+            });
+        }
+
+        if (promptCatalogFailedRef.current) {
+          clearInterval(intervalId);
+          handlePromptCatalogFailure('PromptHub insert failed to resolve');
+        }
+        return;
+      }
 
       if (!shouldAutoSubmit) {
         submissionHandledRef.current = true;
@@ -349,6 +453,10 @@ export default function useQueryParams({
     queryClient,
     processSubmission,
     areSettingsApplied,
+    isAuthenticated,
+    token,
+    showToast,
+    localize,
   ]);
 
   useEffect(() => {
@@ -378,7 +486,6 @@ export default function useQueryParams({
     }
   }, [conversation, processSubmission, areSettingsApplied]);
 
-  const { isAuthenticated } = useAuthContext();
   const agentsMap = useAgentsMap({ isAuthenticated });
   useEffect(() => {
     if (urlAgent) {

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1261,6 +1261,7 @@
   "com_ui_prompt_input_field": "Prompt text input field",
   "com_ui_prompt_name": "Prompt Name",
   "com_ui_prompt_name_required": "Prompt Name is required",
+  "com_ui_prompt_catalog_insert_error": "Unable to load this Prompt Catalog prompt in LibreChat. Please try again.",
   "com_ui_prompt_preview_not_shared": "The author has not allowed collaboration for this prompt.",
   "com_ui_prompt_text": "Text",
   "com_ui_prompt_text_required": "Text is required",

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -108,7 +108,13 @@ export default function ChatRoute() {
 
       const queryParams: Record<string, string> = {};
       searchParams.forEach((value, key) => {
-        if (key !== 'prompt' && key !== 'q' && key !== 'submit') {
+        if (
+          key !== 'prompt' &&
+          key !== 'q' &&
+          key !== 'submit' &&
+          key !== 'promptCatalogId' &&
+          key !== 'prompt_catalog_id'
+        ) {
           queryParams[key] = value;
         }
       });

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -33,6 +33,7 @@ export * from './memory';
 export * from './agents';
 /* Prompts */
 export * from './prompts';
+export * from './promptCatalog';
 /* Endpoints */
 export * from './endpoints';
 /* Files */

--- a/packages/api/src/promptCatalog/handlers.spec.ts
+++ b/packages/api/src/promptCatalog/handlers.spec.ts
@@ -1,0 +1,133 @@
+import { createPromptHubResolveInsertHandler } from './handlers';
+
+describe('createPromptHubResolveInsertHandler', () => {
+  const createResponse = () => {
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    return res;
+  };
+
+  it('returns the prompt content and forwards user identity headers', async () => {
+    const mockFetch = jest.fn() as unknown as jest.MockedFunction<typeof fetch>;
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        id: 254,
+        title: 'Neurodiversity-Friendly Rewriter',
+        content: 'Prompt body',
+        version: 2,
+      }),
+    } as unknown as Awaited<ReturnType<typeof fetch>>);
+
+    const handler = createPromptHubResolveInsertHandler({
+      getPromptCatalogApiUrl: () => 'https://prompt-catalog.example.com',
+      fetchImpl: mockFetch,
+      timeoutMs: 5000,
+    });
+
+    const req = {
+      body: { promptCatalogId: 254 },
+      user: {
+        email: 'teammate@paychex.com',
+        name: 'Teammate Example',
+      },
+    } as Parameters<ReturnType<typeof createPromptHubResolveInsertHandler>>[0];
+    const res = createResponse();
+
+    await handler(req, res as never);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://prompt-catalog.example.com/api/prompts/254',
+      expect.objectContaining({
+        headers: {
+          Accept: 'application/json',
+          'x-forwarded-user-email': 'teammate@paychex.com',
+          'x-forwarded-user-name': 'Teammate Example',
+        },
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      promptId: 254,
+      title: 'Neurodiversity-Friendly Rewriter',
+      content: 'Prompt body',
+      version: 2,
+    });
+  });
+
+  it('rejects invalid prompt IDs', async () => {
+    const mockFetch = jest.fn() as unknown as jest.MockedFunction<typeof fetch>;
+    const handler = createPromptHubResolveInsertHandler({
+      getPromptCatalogApiUrl: () => 'https://prompt-catalog.example.com',
+      fetchImpl: mockFetch,
+    });
+    const res = createResponse();
+
+    await handler({ body: { promptCatalogId: 'abc' } } as never, res as never);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'promptCatalogId is required' });
+  });
+
+  it('returns 500 when the Prompt Catalog base URL is not configured', async () => {
+    const mockFetch = jest.fn() as unknown as jest.MockedFunction<typeof fetch>;
+    const handler = createPromptHubResolveInsertHandler({
+      getPromptCatalogApiUrl: () => undefined,
+      fetchImpl: mockFetch,
+    });
+    const res = createResponse();
+
+    await handler({ body: { promptCatalogId: 254 } } as never, res as never);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ message: 'PROMPT_CATALOG_API_URL is not configured' });
+  });
+
+  it('passes through Prompt Catalog errors', async () => {
+    const mockFetch = jest.fn() as unknown as jest.MockedFunction<typeof fetch>;
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: jest.fn().mockResolvedValue({ error: 'Prompt not found' }),
+    } as unknown as Awaited<ReturnType<typeof fetch>>);
+
+    const handler = createPromptHubResolveInsertHandler({
+      getPromptCatalogApiUrl: () => 'https://prompt-catalog.example.com',
+      fetchImpl: mockFetch,
+    });
+    const res = createResponse();
+
+    await handler({ body: { promptCatalogId: 999 } } as never, res as never);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Prompt not found' });
+  });
+
+  it('returns 502 when Prompt Catalog does not include prompt text', async () => {
+    const mockFetch = jest.fn() as unknown as jest.MockedFunction<typeof fetch>;
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({ id: 254, title: 'Missing content' }),
+    } as unknown as Awaited<ReturnType<typeof fetch>>);
+
+    const handler = createPromptHubResolveInsertHandler({
+      getPromptCatalogApiUrl: () => 'https://prompt-catalog.example.com',
+      fetchImpl: mockFetch,
+    });
+    const res = createResponse();
+
+    await handler({ body: { promptCatalogId: 254 } } as never, res as never);
+
+    expect(res.status).toHaveBeenCalledWith(502);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Prompt Catalog response did not include prompt text',
+    });
+  });
+});

--- a/packages/api/src/promptCatalog/handlers.ts
+++ b/packages/api/src/promptCatalog/handlers.ts
@@ -1,0 +1,148 @@
+import { logger } from '@librechat/data-schemas';
+import type { Request, Response } from 'express';
+
+type PromptCatalogFetch = typeof fetch;
+
+type PromptCatalogResponse = {
+  id?: number;
+  title?: string;
+  content?: string;
+  prompt?: string;
+  error?: string;
+  version?: number;
+};
+
+type PromptCatalogResolveInsertRequest = Request<
+  unknown,
+  unknown,
+  {
+    promptCatalogId?: number | string;
+  }
+> & {
+  user?: {
+    email?: string;
+    name?: string;
+    username?: string;
+  };
+};
+
+export interface PromptCatalogResolveInsertDependencies {
+  getPromptCatalogApiUrl: () => string | undefined;
+  fetchImpl?: PromptCatalogFetch;
+  timeoutMs?: number;
+}
+
+function buildPromptCatalogHeaders(
+  user?: PromptCatalogResolveInsertRequest['user'],
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+  };
+
+  if (user?.email) {
+    headers['x-forwarded-user-email'] = user.email;
+  }
+
+  const forwardedName = user?.name || user?.username || user?.email;
+  if (forwardedName) {
+    headers['x-forwarded-user-name'] = forwardedName;
+  }
+
+  return headers;
+}
+
+function buildPromptCatalogPromptUrl(promptCatalogApiUrl: string, promptId: number): string {
+  const normalizedApiUrl = promptCatalogApiUrl.endsWith('/')
+    ? promptCatalogApiUrl
+    : `${promptCatalogApiUrl}/`;
+
+  return new URL(`/api/prompts/${promptId}`, normalizedApiUrl).toString();
+}
+
+async function parsePromptCatalogResponse(
+  response: Awaited<ReturnType<PromptCatalogFetch>>,
+): Promise<PromptCatalogResponse | null> {
+  try {
+    return (await response.json()) as PromptCatalogResponse;
+  } catch {
+    return null;
+  }
+}
+
+function getTimeoutSignal(timeoutMs: number): AbortSignal | undefined {
+  return typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function'
+    ? AbortSignal.timeout(timeoutMs)
+    : undefined;
+}
+
+export function createPromptHubResolveInsertHandler(deps: PromptCatalogResolveInsertDependencies) {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const timeoutMs = deps.timeoutMs ?? 10_000;
+
+  return async function promptHubResolveInsertHandler(
+    req: PromptCatalogResolveInsertRequest,
+    res: Response,
+  ) {
+    const promptId = Number.parseInt(String(req.body?.promptCatalogId ?? ''), 10);
+    if (!Number.isInteger(promptId) || promptId <= 0) {
+      return res.status(400).json({ message: 'promptCatalogId is required' });
+    }
+
+    const promptCatalogApiUrl = deps.getPromptCatalogApiUrl();
+    if (!promptCatalogApiUrl) {
+      return res.status(500).json({ message: 'PROMPT_CATALOG_API_URL is not configured' });
+    }
+
+    let promptCatalogPromptUrl: string;
+    try {
+      promptCatalogPromptUrl = buildPromptCatalogPromptUrl(promptCatalogApiUrl, promptId);
+    } catch {
+      return res.status(500).json({ message: 'Invalid PROMPT_CATALOG_API_URL' });
+    }
+
+    try {
+      const response = await fetchImpl(promptCatalogPromptUrl, {
+        headers: buildPromptCatalogHeaders(req.user),
+        signal: getTimeoutSignal(timeoutMs),
+      });
+      const data = await parsePromptCatalogResponse(response);
+
+      if (!response.ok) {
+        return res.status(response.status).json({
+          message: data?.error || 'Failed to resolve Prompt Catalog insert',
+        });
+      }
+
+      const promptText =
+        typeof data?.content === 'string'
+          ? data.content
+          : typeof data?.prompt === 'string'
+            ? data.prompt
+            : null;
+
+      if (promptText == null) {
+        return res
+          .status(502)
+          .json({ message: 'Prompt Catalog response did not include prompt text' });
+      }
+
+      const payload: { promptId: number; content: string; title?: string; version?: number } = {
+        promptId: typeof data?.id === 'number' ? data.id : promptId,
+        content: promptText,
+      };
+
+      if (typeof data?.title === 'string') {
+        payload.title = data.title;
+      }
+
+      if (typeof data?.version === 'number') {
+        payload.version = data.version;
+      }
+
+      return res.status(200).json(payload);
+    } catch (error) {
+      logger.error('[PromptHubResolveInsert] Failed to resolve insert:', error);
+      return res.status(502).json({ message: 'Prompt Catalog service unavailable' });
+    }
+  };
+}

--- a/packages/api/src/promptCatalog/handlers.ts
+++ b/packages/api/src/promptCatalog/handlers.ts
@@ -56,7 +56,7 @@ function buildPromptCatalogPromptUrl(promptCatalogApiUrl: string, promptId: numb
     ? promptCatalogApiUrl
     : `${promptCatalogApiUrl}/`;
 
-  return new URL(`/api/prompts/${promptId}`, normalizedApiUrl).toString();
+  return new URL(`api/prompts/${promptId}`, normalizedApiUrl).toString();
 }
 
 async function parsePromptCatalogResponse(

--- a/packages/api/src/promptCatalog/index.ts
+++ b/packages/api/src/promptCatalog/index.ts
@@ -1,0 +1,1 @@
+export * from './handlers';


### PR DESCRIPTION
Implements server-side Prompt Catalog deep-link integration, enabling AI Hub to open LibreChat with a Prompt Catalog ID that resolves to prompt text without exposing full prompts in URLs.

What Changed
- Backend: Added /api/prompthub/resolve-insert route that fetches prompt content from Prompt Catalog API with authenticated user identity headers
- API Layer: Created @librechat/api handlers for server-side prompt resolution with timeout and error handling
- Client: Enhanced query param handling to resolve promptCatalogId, inject content into composer, and display user-facing error toasts on failure
- Config: Added PROMPT_CATALOG_API_URL environment variable