### PR TITLE
feat: add link to Paychex Changelog for LibreChat

### DIFF
--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -92,6 +92,7 @@ router.get('/', async function (req, res) {
         isEnabled(process.env.SHOW_BIRTHDAY_ICON) ||
         process.env.SHOW_BIRTHDAY_ICON === '',
       helpAndFaqURL: process.env.HELP_AND_FAQ_URL || 'https://librechat.ai',
+      changelogURL: 'https://hub.ai.paychex.com/librechat-changelog',
       interface: appConfig?.interfaceConfig,
       turnstile: appConfig?.turnstileConfig,
       modelSpecs: appConfig?.modelSpecs,

--- a/client/src/components/Chat/Footer.tsx
+++ b/client/src/components/Chat/Footer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, memo } from 'react';
+import { ExternalLink } from 'lucide-react';
 import TagManager from 'react-gtm-module';
 import ReactMarkdown from 'react-markdown';
 import { Constants } from 'librechat-data-provider';
@@ -71,6 +72,21 @@ function Footer({ className }: { className?: string }) {
     Boolean,
   );
 
+  const changelogURL = config?.changelogURL;
+  const changelogRender = changelogURL && changelogURL !== '/' && (
+    <a
+      href={changelogURL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-1 text-text-secondary underline hover:text-text-primary"
+    >
+      {localize('com_nav_changelog')}
+      <ExternalLink className="h-3 w-3" aria-hidden="true" />
+    </a>
+  );
+
+  const allFooterElements = [...footerElements, changelogRender].filter(Boolean);
+
   return (
     <div className="relative w-full">
       <div
@@ -80,8 +96,8 @@ function Footer({ className }: { className?: string }) {
         }
         role="contentinfo"
       >
-        {footerElements.map((contentRender, index) => {
-          const isLastElement = index === footerElements.length - 1;
+        {allFooterElements.map((contentRender, index) => {
+          const isLastElement = index === allFooterElements.length - 1;
           return (
             <React.Fragment key={`footer-element-${index}`}>
               {contentRender}

--- a/client/src/components/Nav/AccountSettings.tsx
+++ b/client/src/components/Nav/AccountSettings.tsx
@@ -1,6 +1,6 @@
 import { useState, memo, useRef } from 'react';
 import * as Menu from '@ariakit/react/menu';
-import { FileText, LogOut } from 'lucide-react';
+import { ExternalLink, FileText, LogOut } from 'lucide-react';
 import { LinkIcon, GearIcon, DropdownMenuSeparator, Avatar } from '@librechat/client';
 import { MyFilesModal } from '~/components/Chat/Input/Files/MyFilesModal';
 import { useGetStartupConfig, useGetUserBalance } from '~/data-provider';
@@ -70,6 +70,15 @@ function AccountSettings() {
           >
             <LinkIcon aria-hidden="true" />
             {localize('com_nav_help_faq')}
+          </Menu.MenuItem>
+        )}
+        {startupConfig?.changelogURL && startupConfig.changelogURL !== '/' && (
+          <Menu.MenuItem
+            onClick={() => window.open(startupConfig?.changelogURL, '_blank')}
+            className="select-item text-sm"
+          >
+            <ExternalLink className="icon-md" aria-hidden="true" />
+            {localize('com_nav_changelog')}
           </Menu.MenuItem>
         )}
         <Menu.MenuItem onClick={() => setShowSettings(true)} className="select-item text-sm">

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -484,6 +484,7 @@
   "com_nav_font_size_xl": "Extra Large",
   "com_nav_font_size_xs": "Extra Small",
   "com_nav_help_faq": "Help & FAQ",
+  "com_nav_changelog": "Paychex Changelog",
   "com_nav_hide_panel": "Hide right-most side panel",
   "com_nav_info_balance": "Balance shows how many token credits you have left to use. Token credits translate to monetary value (e.g., 1000 credits = $0.001 USD)",
   "com_nav_info_code_artifacts": "Enables the display of experimental code artifacts next to the chat",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -775,6 +775,7 @@ export type TStartupConfig = {
   emailEnabled: boolean;
   showBirthdayIcon: boolean;
   helpAndFaqURL: string;
+  changelogURL?: string;
   customFooter?: string;
   modelSpecs?: TSpecsConfig;
   modelDescriptions?: Record<string, Record<string, string>>;


### PR DESCRIPTION
Adds Paychex Changelog link to both footer and account settings menu. Configurable via changelogURL in startup config, defaults to https://hub.ai.paychex.com/librechat-changelog.