### PR TITLE
Feature/openid access token refresh

### DIFF
--- a/api/server/middleware/index.js
+++ b/api/server/middleware/index.js
@@ -10,6 +10,7 @@ const requireLdapAuth = require('./requireLdapAuth');
 const abortMiddleware = require('./abortMiddleware');
 const checkInviteUser = require('./checkInviteUser');
 const requireJwtAuth = require('./requireJwtAuth');
+const refreshOpenIDToken = require('./refreshOpenIDToken');
 const configMiddleware = require('./config/app');
 const validateModel = require('./validateModel');
 const moderateText = require('./moderateText');
@@ -36,6 +37,7 @@ module.exports = {
   moderateText,
   validateModel,
   requireJwtAuth,
+  refreshOpenIDToken,
   checkInviteUser,
   requireLdapAuth,
   requireLocalAuth,

--- a/api/server/middleware/refreshOpenIDToken.js
+++ b/api/server/middleware/refreshOpenIDToken.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const cookies = require('cookie');
+const openIdClient = require('openid-client');
+const { logger } = require('@librechat/data-schemas');
+const { isEnabled } = require('@librechat/api');
+const { getOpenIdConfig } = require('~/strategies');
+const { setOpenIDAuthTokens } = require('~/server/services/AuthService');
+
+/**
+ * Parse a JWT and return the decoded payload without signature verification.
+ * Returns null for opaque tokens (non-JWT strings).
+ *
+ * @param {string} token
+ * @returns {Record<string, unknown> | null}
+ */
+function parseJwtPayload(token) {
+  if (!token || typeof token !== 'string') {
+    return null;
+  }
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return null;
+  }
+  try {
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns true when the access_token JWT is expired or will expire within `bufferSeconds`.
+ * Returns false for opaque tokens (cannot determine expiry without network call).
+ *
+ * @param {string} accessToken
+ * @param {number} [bufferSeconds=30]
+ * @returns {boolean}
+ */
+function isAccessTokenExpiredOrExpiringSoon(accessToken, bufferSeconds = 30) {
+  const payload = parseJwtPayload(accessToken);
+  if (!payload || !payload.exp) {
+    return false;
+  }
+  const now = Math.floor(Date.now() / 1000);
+  return now >= /** @type {number} */ (payload.exp) - bufferSeconds;
+}
+
+/**
+ * Middleware that proactively refreshes an expired or expiring OpenID access_token
+ * before the request reaches the agent/MCP handler.
+ *
+ * Problem this solves:
+ *   LibreChat authenticates users with the OpenID id_token (~60+ min lifetime).
+ *   Downstream agents such as Paxton receive the access_token forwarded via the
+ *   {{LIBRECHAT_OPENID_ACCESS_TOKEN}} placeholder, which can have a shorter lifetime
+ *   (e.g. ~15 min for Azure AD). After the access_token expires the id_token may
+ *   still be valid, so requireJwtAuth succeeds but the agent call returns 401.
+ *
+ * This middleware detects an expired/expiring access_token and performs a silent
+ * refresh using the stored refresh_token before the request continues.
+ *
+ * Only active when:
+ *   - OPENID_REUSE_TOKENS is enabled (required for token forwarding to agents)
+ *   - token_provider cookie is 'openid'
+ *   - req.user.federatedTokens contains an access_token
+ *   - The access_token is expired or expires within 30 seconds
+ *   - A refresh_token is available in the session or refreshToken cookie
+ *
+ * On refresh failure the middleware logs a warning and proceeds so that the
+ * downstream 401 surfaces normally rather than silently breaking the request.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
+ */
+const refreshOpenIDToken = async (req, res, next) => {
+  if (!isEnabled(process.env.OPENID_REUSE_TOKENS)) {
+    return next();
+  }
+
+  const cookieHeader = req.headers.cookie;
+  const parsedCookies = cookieHeader ? cookies.parse(cookieHeader) : {};
+
+  if (parsedCookies.token_provider !== 'openid') {
+    return next();
+  }
+
+  const accessToken = req.user?.federatedTokens?.access_token;
+  if (!accessToken || !isAccessTokenExpiredOrExpiringSoon(accessToken)) {
+    return next();
+  }
+
+  const refreshToken =
+    req.session?.openidTokens?.refreshToken || parsedCookies.refreshToken;
+
+  if (!refreshToken) {
+    logger.warn('[refreshOpenIDToken] Access token expired but no refresh token available');
+    return next();
+  }
+
+  try {
+    logger.debug('[refreshOpenIDToken] Access token expired or expiring soon — refreshing');
+
+    const openIdConfig = getOpenIdConfig();
+    const refreshParams = process.env.OPENID_SCOPE ? { scope: process.env.OPENID_SCOPE } : {};
+    const tokenset = await openIdClient.refreshTokenGrant(
+      openIdConfig,
+      refreshToken,
+      refreshParams,
+    );
+
+    const userId = req.user?.id;
+
+    /** Persist new tokens in session + update response cookies */
+    setOpenIDAuthTokens(tokenset, req, res, userId, refreshToken);
+
+    /** Update req.user.federatedTokens so the current request uses the fresh access_token */
+    req.user.federatedTokens = {
+      access_token: tokenset.access_token,
+      id_token: tokenset.id_token,
+      refresh_token: tokenset.refresh_token || refreshToken,
+      expires_at: tokenset.expires_at,
+    };
+
+    logger.info('[refreshOpenIDToken] Access token refreshed successfully');
+  } catch (err) {
+    logger.warn('[refreshOpenIDToken] Failed to refresh access token — proceeding with expired token', {
+      error: err.message,
+    });
+  }
+
+  return next();
+};
+
+module.exports = refreshOpenIDToken;

--- a/api/server/middleware/refreshOpenIDToken.js
+++ b/api/server/middleware/refreshOpenIDToken.js
@@ -72,8 +72,7 @@ function isAccessTokenExpiredOrExpiringSoon(accessToken, bufferSeconds = 30) {
  * Only active when:
  *   - OPENID_REUSE_TOKENS is enabled (required for token forwarding to agents)
  *   - token_provider cookie is 'openid'
- *   - req.user.federatedTokens contains an access_token
- *   - The access_token is expired or expires within 30 seconds
+ *   - The session access_token is absent (session expired) OR expires within 30 seconds
  *   - A refresh_token is available in the session or refreshToken cookie
  *
  * On refresh failure the middleware logs a warning and proceeds so that the
@@ -95,8 +94,14 @@ const refreshOpenIDToken = async (req, res, next) => {
     return next();
   }
 
-  const accessToken = req.user?.federatedTokens?.access_token;
-  if (!accessToken || !isAccessTokenExpiredOrExpiringSoon(accessToken)) {
+  // Use the session's stored access_token for the expiry check.
+  // When the express session expires (SESSION_EXPIRY, default 15 min), openIdJwtStrategy falls
+  // back to using the id_token (Bearer token) as federatedTokens.access_token. The id_token
+  // has a longer lifetime so isAccessTokenExpiredOrExpiringSoon would return false — but the
+  // id_token is NOT a valid access_token for downstream services like Paxton.
+  // Refresh whenever the session access_token is absent (session expired) OR expiring soon.
+  const sessionAccessToken = req.session?.openidTokens?.accessToken;
+  if (sessionAccessToken && !isAccessTokenExpiredOrExpiringSoon(sessionAccessToken)) {
     return next();
   }
 

--- a/api/server/middleware/refreshOpenIDToken.js
+++ b/api/server/middleware/refreshOpenIDToken.js
@@ -8,6 +8,15 @@ const { getOpenIdConfig } = require('~/strategies');
 const { setOpenIDAuthTokens } = require('~/server/services/AuthService');
 
 /**
+ * Per-user in-flight refresh promise map.
+ * Prevents concurrent requests for the same user from each independently calling
+ * refreshTokenGrant and triggering a rotate-on-use invalidation race (invalid_grant).
+ *
+ * @type {Map<string, Promise<unknown>>}
+ */
+const _inflight = new Map();
+
+/**
  * Parse a JWT and return the decoded payload without signature verification.
  * Returns null for opaque tokens (non-JWT strings).
  *
@@ -99,18 +108,29 @@ const refreshOpenIDToken = async (req, res, next) => {
     return next();
   }
 
+  const userId = req.user?.id;
+
   try {
     logger.debug('[refreshOpenIDToken] Access token expired or expiring soon — refreshing');
 
-    const openIdConfig = getOpenIdConfig();
-    const refreshParams = process.env.OPENID_SCOPE ? { scope: process.env.OPENID_SCOPE } : {};
-    const tokenset = await openIdClient.refreshTokenGrant(
-      openIdConfig,
-      refreshToken,
-      refreshParams,
-    );
+    let refreshPromise = userId ? _inflight.get(userId) : null;
 
-    const userId = req.user?.id;
+    if (!refreshPromise) {
+      const openIdConfig = getOpenIdConfig();
+      const refreshParams = process.env.OPENID_SCOPE ? { scope: process.env.OPENID_SCOPE } : {};
+      refreshPromise = openIdClient
+        .refreshTokenGrant(openIdConfig, refreshToken, refreshParams)
+        .finally(() => {
+          if (userId) {
+            _inflight.delete(userId);
+          }
+        });
+      if (userId) {
+        _inflight.set(userId, refreshPromise);
+      }
+    }
+
+    const tokenset = await refreshPromise;
 
     /** Persist new tokens in session + update response cookies */
     setOpenIDAuthTokens(tokenset, req, res, userId, refreshToken);

--- a/api/server/middleware/refreshOpenIDToken.js
+++ b/api/server/middleware/refreshOpenIDToken.js
@@ -100,8 +100,7 @@ const refreshOpenIDToken = async (req, res, next) => {
     return next();
   }
 
-  const refreshToken =
-    req.session?.openidTokens?.refreshToken || parsedCookies.refreshToken;
+  const refreshToken = req.session?.openidTokens?.refreshToken || parsedCookies.refreshToken;
 
   if (!refreshToken) {
     logger.warn('[refreshOpenIDToken] Access token expired but no refresh token available');
@@ -145,9 +144,12 @@ const refreshOpenIDToken = async (req, res, next) => {
 
     logger.info('[refreshOpenIDToken] Access token refreshed successfully');
   } catch (err) {
-    logger.warn('[refreshOpenIDToken] Failed to refresh access token — proceeding with expired token', {
-      error: err.message,
-    });
+    logger.warn(
+      '[refreshOpenIDToken] Failed to refresh access token — proceeding with expired token',
+      {
+        error: err.message,
+      },
+    );
   }
 
   return next();

--- a/api/server/middleware/refreshOpenIDToken.spec.js
+++ b/api/server/middleware/refreshOpenIDToken.spec.js
@@ -1,0 +1,262 @@
+'use strict';
+
+const refreshOpenIDToken = require('./refreshOpenIDToken');
+
+jest.mock('cookie', () => ({
+  parse: jest.fn(),
+}));
+
+jest.mock('@librechat/api', () => ({
+  isEnabled: jest.fn(),
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('~/strategies', () => ({
+  getOpenIdConfig: jest.fn(),
+}));
+
+jest.mock('~/server/services/AuthService', () => ({
+  setOpenIDAuthTokens: jest.fn(),
+}));
+
+jest.mock('openid-client', () => ({
+  refreshTokenGrant: jest.fn(),
+}));
+
+const cookieLib = require('cookie');
+const { isEnabled } = require('@librechat/api');
+const { getOpenIdConfig } = require('~/strategies');
+const { setOpenIDAuthTokens } = require('~/server/services/AuthService');
+const openIdClient = require('openid-client');
+
+/**
+ * Build a compact JWT with the given payload (unsigned, for test purposes only).
+ */
+function buildTestJwt(payload) {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.fakesig`;
+}
+
+function makeReq({ cookieStr = 'token_provider=openid', user = null, session = null } = {}) {
+  return {
+    headers: { cookie: cookieStr },
+    user,
+    session,
+  };
+}
+
+function makeRes() {
+  return { cookie: jest.fn() };
+}
+
+describe('refreshOpenIDToken middleware', () => {
+  const now = Math.floor(Date.now() / 1000);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isEnabled.mockReturnValue(true);
+    cookieLib.parse.mockReturnValue({ token_provider: 'openid' });
+    getOpenIdConfig.mockReturnValue({ issuer: 'https://example.com' });
+  });
+
+  it('calls next immediately when OPENID_REUSE_TOKENS is disabled', async () => {
+    isEnabled.mockReturnValue(false);
+    const next = jest.fn();
+    await refreshOpenIDToken(makeReq(), makeRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(openIdClient.refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('calls next immediately when token_provider is not openid', async () => {
+    cookieLib.parse.mockReturnValue({ token_provider: 'librechat' });
+    const next = jest.fn();
+    await refreshOpenIDToken(makeReq({ cookieStr: 'token_provider=librechat' }), makeRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(openIdClient.refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('calls next immediately when user has no federatedTokens', async () => {
+    const next = jest.fn();
+    await refreshOpenIDToken(makeReq({ user: { id: 'u1' } }), makeRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(openIdClient.refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('calls next immediately when access_token is still valid', async () => {
+    const validToken = buildTestJwt({ exp: now + 3600 });
+    const req = makeReq({
+      user: { id: 'u1', federatedTokens: { access_token: validToken } },
+    });
+    const next = jest.fn();
+    await refreshOpenIDToken(req, makeRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(openIdClient.refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('calls next without refresh when access_token is an opaque token (no exp)', async () => {
+    const next = jest.fn();
+    const req = makeReq({
+      user: { id: 'u1', federatedTokens: { access_token: 'opaque-token-string' } },
+    });
+    await refreshOpenIDToken(req, makeRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(openIdClient.refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('calls next with warning when access_token is expired but no refresh_token available', async () => {
+    const expiredToken = buildTestJwt({ exp: now - 60 });
+    const next = jest.fn();
+    cookieLib.parse.mockReturnValue({ token_provider: 'openid' }); // no refreshToken cookie
+    const req = makeReq({
+      cookieStr: 'token_provider=openid',
+      user: { id: 'u1', federatedTokens: { access_token: expiredToken } },
+      session: { openidTokens: {} }, // no refreshToken in session
+    });
+    await refreshOpenIDToken(req, makeRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(openIdClient.refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('refreshes expired access_token using session refresh_token', async () => {
+    const expiredToken = buildTestJwt({ exp: now - 60 });
+    const newTokenset = {
+      access_token: 'new-access-token',
+      id_token: 'new-id-token',
+      refresh_token: 'new-refresh-token',
+      expires_at: now + 3600,
+    };
+    openIdClient.refreshTokenGrant.mockResolvedValue(newTokenset);
+
+    const next = jest.fn();
+    const req = makeReq({
+      user: { id: 'u1', federatedTokens: { access_token: expiredToken } },
+      session: { openidTokens: { refreshToken: 'old-refresh-token' } },
+    });
+    const res = makeRes();
+
+    await refreshOpenIDToken(req, res, next);
+
+    expect(openIdClient.refreshTokenGrant).toHaveBeenCalledWith(
+      expect.anything(),
+      'old-refresh-token',
+      expect.anything(),
+    );
+    expect(setOpenIDAuthTokens).toHaveBeenCalledWith(
+      newTokenset,
+      req,
+      res,
+      'u1',
+      'old-refresh-token',
+    );
+    expect(req.user.federatedTokens).toEqual({
+      access_token: 'new-access-token',
+      id_token: 'new-id-token',
+      refresh_token: 'new-refresh-token',
+      expires_at: now + 3600,
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes expired access_token using refreshToken cookie as fallback', async () => {
+    const expiredToken = buildTestJwt({ exp: now - 60 });
+    const newTokenset = {
+      access_token: 'new-access-token',
+      id_token: 'new-id-token',
+      refresh_token: undefined,
+      expires_at: now + 3600,
+    };
+    openIdClient.refreshTokenGrant.mockResolvedValue(newTokenset);
+    cookieLib.parse.mockReturnValue({ token_provider: 'openid', refreshToken: 'cookie-refresh' });
+
+    const next = jest.fn();
+    const req = makeReq({
+      user: { id: 'u1', federatedTokens: { access_token: expiredToken } },
+      session: { openidTokens: {} }, // no refreshToken in session
+    });
+
+    await refreshOpenIDToken(req, makeRes(), next);
+
+    expect(openIdClient.refreshTokenGrant).toHaveBeenCalledWith(
+      expect.anything(),
+      'cookie-refresh',
+      expect.anything(),
+    );
+    expect(req.user.federatedTokens.refresh_token).toBe('cookie-refresh');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes token expiring within 30-second buffer', async () => {
+    const soonExpiring = buildTestJwt({ exp: now + 15 }); // expires in 15s < 30s buffer
+    const newTokenset = {
+      access_token: 'new-access-token',
+      id_token: 'new-id-token',
+      refresh_token: 'new-refresh-token',
+      expires_at: now + 3600,
+    };
+    openIdClient.refreshTokenGrant.mockResolvedValue(newTokenset);
+
+    const next = jest.fn();
+    const req = makeReq({
+      user: { id: 'u1', federatedTokens: { access_token: soonExpiring } },
+      session: { openidTokens: { refreshToken: 'old-refresh-token' } },
+    });
+
+    await refreshOpenIDToken(req, makeRes(), next);
+
+    expect(openIdClient.refreshTokenGrant).toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls next and logs warning when refresh grant fails', async () => {
+    const { logger } = require('@librechat/data-schemas');
+    const expiredToken = buildTestJwt({ exp: now - 60 });
+    openIdClient.refreshTokenGrant.mockRejectedValue(new Error('invalid_grant'));
+
+    const next = jest.fn();
+    const req = makeReq({
+      user: { id: 'u1', federatedTokens: { access_token: expiredToken } },
+      session: { openidTokens: { refreshToken: 'stale-refresh-token' } },
+    });
+
+    await refreshOpenIDToken(req, makeRes(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to refresh'),
+      expect.objectContaining({ error: 'invalid_grant' }),
+    );
+    expect(req.user.federatedTokens.access_token).toBe(expiredToken);
+  });
+
+  it('passes OPENID_SCOPE as refresh params when env var is set', async () => {
+    const expiredToken = buildTestJwt({ exp: now - 60 });
+    process.env.OPENID_SCOPE = 'openid profile email';
+    openIdClient.refreshTokenGrant.mockResolvedValue({
+      access_token: 'new-token',
+      id_token: 'id',
+      refresh_token: 'rt',
+      expires_at: now + 3600,
+    });
+
+    const next = jest.fn();
+    const req = makeReq({
+      user: { id: 'u1', federatedTokens: { access_token: expiredToken } },
+      session: { openidTokens: { refreshToken: 'rt' } },
+    });
+
+    await refreshOpenIDToken(req, makeRes(), next);
+
+    expect(openIdClient.refreshTokenGrant).toHaveBeenCalledWith(
+      expect.anything(),
+      'rt',
+      { scope: 'openid profile email' },
+    );
+
+    delete process.env.OPENID_SCOPE;
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/api/server/middleware/refreshOpenIDToken.spec.js
+++ b/api/server/middleware/refreshOpenIDToken.spec.js
@@ -259,4 +259,75 @@ describe('refreshOpenIDToken middleware', () => {
     delete process.env.OPENID_SCOPE;
     expect(next).toHaveBeenCalledTimes(1);
   });
+
+  it('deduplicates concurrent refresh grants for the same user', async () => {
+    const expiredToken = buildTestJwt({ exp: now - 60 });
+    const newTokenset = {
+      access_token: 'new-access-token',
+      id_token: 'new-id-token',
+      refresh_token: 'new-refresh-token',
+      expires_at: now + 3600,
+    };
+    openIdClient.refreshTokenGrant.mockResolvedValue(newTokenset);
+
+    const next1 = jest.fn();
+    const next2 = jest.fn();
+    const req1 = makeReq({
+      user: { id: 'concurrent-user', federatedTokens: { access_token: expiredToken } },
+      session: { openidTokens: { refreshToken: 'rt' } },
+    });
+    const req2 = makeReq({
+      user: { id: 'concurrent-user', federatedTokens: { access_token: expiredToken } },
+      session: { openidTokens: { refreshToken: 'rt' } },
+    });
+
+    await Promise.all([
+      refreshOpenIDToken(req1, makeRes(), next1),
+      refreshOpenIDToken(req2, makeRes(), next2),
+    ]);
+
+    // Only one grant issued despite two concurrent requests
+    expect(openIdClient.refreshTokenGrant).toHaveBeenCalledTimes(1);
+
+    // Both requests receive the fresh token
+    expect(req1.user.federatedTokens.access_token).toBe('new-access-token');
+    expect(req2.user.federatedTokens.access_token).toBe('new-access-token');
+
+    expect(next1).toHaveBeenCalledTimes(1);
+    expect(next2).toHaveBeenCalledTimes(1);
+  });
+
+  it('both concurrent requests fall through when the shared refresh grant fails', async () => {
+    const { logger } = require('@librechat/data-schemas');
+    const expiredToken = buildTestJwt({ exp: now - 60 });
+    openIdClient.refreshTokenGrant.mockRejectedValue(new Error('invalid_grant'));
+
+    const next1 = jest.fn();
+    const next2 = jest.fn();
+    const req1 = makeReq({
+      user: { id: 'concurrent-user-2', federatedTokens: { access_token: expiredToken } },
+      session: { openidTokens: { refreshToken: 'rt' } },
+    });
+    const req2 = makeReq({
+      user: { id: 'concurrent-user-2', federatedTokens: { access_token: expiredToken } },
+      session: { openidTokens: { refreshToken: 'rt' } },
+    });
+
+    await Promise.all([
+      refreshOpenIDToken(req1, makeRes(), next1),
+      refreshOpenIDToken(req2, makeRes(), next2),
+    ]);
+
+    // Only one grant attempt despite two concurrent requests
+    expect(openIdClient.refreshTokenGrant).toHaveBeenCalledTimes(1);
+
+    // Both fall through to next without throwing
+    expect(next1).toHaveBeenCalledTimes(1);
+    expect(next2).toHaveBeenCalledTimes(1);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to refresh'),
+      expect.objectContaining({ error: 'invalid_grant' }),
+    );
+  });
 });

--- a/api/server/middleware/refreshOpenIDToken.spec.js
+++ b/api/server/middleware/refreshOpenIDToken.spec.js
@@ -250,11 +250,9 @@ describe('refreshOpenIDToken middleware', () => {
 
     await refreshOpenIDToken(req, makeRes(), next);
 
-    expect(openIdClient.refreshTokenGrant).toHaveBeenCalledWith(
-      expect.anything(),
-      'rt',
-      { scope: 'openid profile email' },
-    );
+    expect(openIdClient.refreshTokenGrant).toHaveBeenCalledWith(expect.anything(), 'rt', {
+      scope: 'openid profile email',
+    });
 
     delete process.env.OPENID_SCOPE;
     expect(next).toHaveBeenCalledTimes(1);

--- a/api/server/middleware/refreshOpenIDToken.spec.js
+++ b/api/server/middleware/refreshOpenIDToken.spec.js
@@ -86,10 +86,11 @@ describe('refreshOpenIDToken middleware', () => {
     expect(openIdClient.refreshTokenGrant).not.toHaveBeenCalled();
   });
 
-  it('calls next immediately when access_token is still valid', async () => {
+  it('calls next immediately when session access_token is still valid', async () => {
     const validToken = buildTestJwt({ exp: now + 3600 });
     const req = makeReq({
       user: { id: 'u1', federatedTokens: { access_token: validToken } },
+      session: { openidTokens: { accessToken: validToken } },
     });
     const next = jest.fn();
     await refreshOpenIDToken(req, makeRes(), next);
@@ -97,28 +98,60 @@ describe('refreshOpenIDToken middleware', () => {
     expect(openIdClient.refreshTokenGrant).not.toHaveBeenCalled();
   });
 
-  it('calls next without refresh when access_token is an opaque token (no exp)', async () => {
+  it('calls next without refresh when session access_token is an opaque token (no exp)', async () => {
     const next = jest.fn();
     const req = makeReq({
       user: { id: 'u1', federatedTokens: { access_token: 'opaque-token-string' } },
+      session: { openidTokens: { accessToken: 'opaque-token-string' } },
     });
     await refreshOpenIDToken(req, makeRes(), next);
     expect(next).toHaveBeenCalledTimes(1);
     expect(openIdClient.refreshTokenGrant).not.toHaveBeenCalled();
   });
 
-  it('calls next with warning when access_token is expired but no refresh_token available', async () => {
+  it('calls next with warning when session access_token is expired but no refresh_token available', async () => {
     const expiredToken = buildTestJwt({ exp: now - 60 });
     const next = jest.fn();
     cookieLib.parse.mockReturnValue({ token_provider: 'openid' }); // no refreshToken cookie
     const req = makeReq({
       cookieStr: 'token_provider=openid',
       user: { id: 'u1', federatedTokens: { access_token: expiredToken } },
-      session: { openidTokens: {} }, // no refreshToken in session
+      session: { openidTokens: { accessToken: expiredToken } }, // no refreshToken in session
     });
     await refreshOpenIDToken(req, makeRes(), next);
     expect(next).toHaveBeenCalledTimes(1);
     expect(openIdClient.refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('refreshes when session has expired (no session accessToken) but OIDC refresh_token is available', async () => {
+    // Simulates the root cause: express session expires after ~15 min. openIdJwtStrategy falls
+    // back to using the id_token (Bearer) as access_token. Without a session access_token,
+    // the middleware must refresh to obtain a real access_token for downstream services.
+    const idToken = buildTestJwt({ exp: now + 3600 }); // still-valid id_token used as Bearer
+    const newTokenset = {
+      access_token: 'fresh-access-token',
+      id_token: 'new-id-token',
+      refresh_token: 'new-refresh-token',
+      expires_at: now + 900,
+    };
+    openIdClient.refreshTokenGrant.mockResolvedValue(newTokenset);
+    cookieLib.parse.mockReturnValue({ token_provider: 'openid', refreshToken: 'oidc-refresh' });
+
+    const next = jest.fn();
+    const req = makeReq({
+      user: { id: 'u1', federatedTokens: { access_token: idToken } }, // id_token masquerading as access_token
+      session: { openidTokens: {} }, // session expired — no accessToken stored
+    });
+
+    await refreshOpenIDToken(req, makeReq(), next);
+
+    expect(openIdClient.refreshTokenGrant).toHaveBeenCalledWith(
+      expect.anything(),
+      'oidc-refresh',
+      expect.anything(),
+    );
+    expect(req.user.federatedTokens.access_token).toBe('fresh-access-token');
+    expect(next).toHaveBeenCalledTimes(1);
   });
 
   it('refreshes expired access_token using session refresh_token', async () => {
@@ -134,7 +167,7 @@ describe('refreshOpenIDToken middleware', () => {
     const next = jest.fn();
     const req = makeReq({
       user: { id: 'u1', federatedTokens: { access_token: expiredToken } },
-      session: { openidTokens: { refreshToken: 'old-refresh-token' } },
+      session: { openidTokens: { accessToken: expiredToken, refreshToken: 'old-refresh-token' } },
     });
     const res = makeRes();
 
@@ -175,7 +208,7 @@ describe('refreshOpenIDToken middleware', () => {
     const next = jest.fn();
     const req = makeReq({
       user: { id: 'u1', federatedTokens: { access_token: expiredToken } },
-      session: { openidTokens: {} }, // no refreshToken in session
+      session: { openidTokens: { accessToken: expiredToken } }, // no refreshToken in session, falls back to cookie
     });
 
     await refreshOpenIDToken(req, makeRes(), next);
@@ -202,7 +235,7 @@ describe('refreshOpenIDToken middleware', () => {
     const next = jest.fn();
     const req = makeReq({
       user: { id: 'u1', federatedTokens: { access_token: soonExpiring } },
-      session: { openidTokens: { refreshToken: 'old-refresh-token' } },
+      session: { openidTokens: { accessToken: soonExpiring, refreshToken: 'old-refresh-token' } },
     });
 
     await refreshOpenIDToken(req, makeRes(), next);
@@ -219,7 +252,7 @@ describe('refreshOpenIDToken middleware', () => {
     const next = jest.fn();
     const req = makeReq({
       user: { id: 'u1', federatedTokens: { access_token: expiredToken } },
-      session: { openidTokens: { refreshToken: 'stale-refresh-token' } },
+      session: { openidTokens: { accessToken: expiredToken, refreshToken: 'stale-refresh-token' } },
     });
 
     await refreshOpenIDToken(req, makeRes(), next);
@@ -245,7 +278,7 @@ describe('refreshOpenIDToken middleware', () => {
     const next = jest.fn();
     const req = makeReq({
       user: { id: 'u1', federatedTokens: { access_token: expiredToken } },
-      session: { openidTokens: { refreshToken: 'rt' } },
+      session: { openidTokens: { accessToken: expiredToken, refreshToken: 'rt' } },
     });
 
     await refreshOpenIDToken(req, makeRes(), next);
@@ -272,11 +305,11 @@ describe('refreshOpenIDToken middleware', () => {
     const next2 = jest.fn();
     const req1 = makeReq({
       user: { id: 'concurrent-user', federatedTokens: { access_token: expiredToken } },
-      session: { openidTokens: { refreshToken: 'rt' } },
+      session: { openidTokens: { accessToken: expiredToken, refreshToken: 'rt' } },
     });
     const req2 = makeReq({
       user: { id: 'concurrent-user', federatedTokens: { access_token: expiredToken } },
-      session: { openidTokens: { refreshToken: 'rt' } },
+      session: { openidTokens: { accessToken: expiredToken, refreshToken: 'rt' } },
     });
 
     await Promise.all([
@@ -304,11 +337,11 @@ describe('refreshOpenIDToken middleware', () => {
     const next2 = jest.fn();
     const req1 = makeReq({
       user: { id: 'concurrent-user-2', federatedTokens: { access_token: expiredToken } },
-      session: { openidTokens: { refreshToken: 'rt' } },
+      session: { openidTokens: { accessToken: expiredToken, refreshToken: 'rt' } },
     });
     const req2 = makeReq({
       user: { id: 'concurrent-user-2', federatedTokens: { access_token: expiredToken } },
-      session: { openidTokens: { refreshToken: 'rt' } },
+      session: { openidTokens: { accessToken: expiredToken, refreshToken: 'rt' } },
     });
 
     await Promise.all([

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -5,6 +5,7 @@ const {
   uaParser,
   checkBan,
   requireJwtAuth,
+  refreshOpenIDToken,
   messageIpLimiter,
   configMiddleware,
   messageUserLimiter,
@@ -34,6 +35,7 @@ router.use('/v1/responses', responses);
 router.use('/v1', openai);
 
 router.use(requireJwtAuth);
+router.use(refreshOpenIDToken);
 router.use(checkBan);
 router.use(uaParser);
 


### PR DESCRIPTION
fix(auth): refresh when session expires and access_token falls back to id_token
Root cause of the Paxton 401 after ~15 minutes:
- Express session expires after SESSION_EXPIRY (default 15 min)
- openIdJwtStrategy falls back to using the id_token (Bearer token) as
  federatedTokens.access_token when session.openidTokens is absent
- id_token is still valid (~60-90 min), so isAccessTokenExpiredOrExpiringSoon
  returned false and the middleware skipped the refresh
- id_token is then forwarded to Paxton via {{LIBRECHAT_OPENID_ACCESS_TOKEN}}
  placeholder -> Paxton returns 401 (wrong audience/token type)

Fix: check req.session.openidTokens.accessToken (the real OIDC access_token)
instead of req.user.federatedTokens.access_token (which may be the id_token
after session expiry). Refresh whenever the session access_token is absent
(session expired) OR expiring soon. OIDC refresh_token persists in a long-
lived httpOnly cookie so refresh is still possible after session expiry.