### PR TITLE
feat: add native DEFAULT badge to ModelSpecItem for default model specs

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
@@ -46,7 +46,8 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
                 aria-label={localize('com_ui_default_model_aria')}
                 title={localize('com_ui_default_model_aria')}
               >
-                ★ {localize('com_ui_default_model')}
+                {/* eslint-disable-next-line i18next/no-literal-string */}
+                <span aria-hidden="true">★</span> {localize('com_ui_default_model')}
               </span>
             )}
           </span>

--- a/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
@@ -38,7 +38,18 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
           </div>
         )}
         <div className="flex min-w-0 flex-col gap-1">
-          <span className="truncate text-left">{spec.label}</span>
+          <span className="flex min-w-0 items-center gap-1.5 text-left">
+            <span className="truncate">{spec.label}</span>
+            {spec.default === true && (
+              <span
+                className="inline-flex items-center gap-0.5 rounded border border-yellow-500/60 bg-yellow-400/10 px-1 py-0.5 text-[10px] font-semibold leading-none text-yellow-600 dark:border-yellow-400/50 dark:text-yellow-400"
+                aria-label={localize('com_ui_default_model_aria')}
+                title={localize('com_ui_default_model_aria')}
+              >
+                ★ {localize('com_ui_default_model')}
+              </span>
+            )}
+          </span>
           {spec.description && (
             <span className="break-words text-xs font-normal">{spec.description}</span>
           )}

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -905,6 +905,8 @@
   "com_ui_date_today": "Today",
   "com_ui_date_yesterday": "Yesterday",
   "com_ui_decline": "I do not accept",
+  "com_ui_default_model": "DEFAULT",
+  "com_ui_default_model_aria": "Default model",
   "com_ui_default_post_request": "Default (POST request)",
   "com_ui_delete": "Delete",
   "com_ui_delete_action": "Delete Action",


### PR DESCRIPTION
Replaces the Pendo-injected DEFAULT badge with a native React implementation. The badge renders when spec.default === true, so it always tracks whichever model spec is marked as default in the config, regardless of model name.

Adds com_ui_default_model and com_ui_default_model_aria localization keys.