### PR TITLE
fix: skip successful OAuth redirects in loginLimiter to prevent SSO rate limit false positives

### DIFF
--- a/api/server/middleware/limiters/loginLimiter.js
+++ b/api/server/middleware/limiters/loginLimiter.js
@@ -25,6 +25,7 @@ const limiterOptions = {
   windowMs,
   max,
   handler,
+  skipSuccessfulRequests: true,
   keyGenerator: removePorts,
   store: limiterCache('login_limiter'),
 };


### PR DESCRIPTION
## Problem

Users randomly receive a `{"message":"Too many login attempts, please try again after 5 minutes."}` error. This occurs when a session goes stale and all open browser tabs simultaneously attempt to re-authenticate through Azure Entra ID SSO.

### Root cause

The `loginLimiter` middleware is applied to the entire `/oauth` router (`router.use(loginLimiter)`), so **every** step of the SSO flow counts against the 7-request-per-5-minute limit:

- `GET /oauth/openid` — initial redirect to Microsoft Entra (+1)
- `GET /oauth/openid/callback` — Entra's return to LibreChat (+1)

Each complete login cycle consumes **2 slots**. When a user has multiple tabs open and their JWT expires, all tabs simultaneously trigger re-authentication, exhausting the limit in seconds. With Redis as a shared store across all replicas, the counter is global, making this worse.

The workaround users discovered (close all tabs → open incognito) works because:
1. Closing tabs stops the flood of competing re-auth requests
2. The 5-minute window expires before they open incognito
3. A single fresh tab completes the 2-request OAuth flow under the limit

## Fix

Add `skipSuccessfulRequests: true` to the `loginLimiter` options.

With `express-rate-limit` v8, responses with status `< 400` are not counted. Every step of the Azure Entra SSO flow returns a **302 redirect**, so normal logins never deplete the counter. The rate limiter now only activates for genuine `4xx`/`5xx` errors on the OAuth routes (e.g., server malfunction), which is the appropriate protection boundary.

## Testing

- Verified `express-rate-limit ^8.3.0` supports `skipSuccessfulRequests`
- N2A environment already has `LOGIN_MAX=5000` as a workaround confirming this is a known issue; this fix addresses the root cause properly for all environments