### PR TITLE
test(e2e): skip deployed-incompatible specs on non-local envs

### DIFF
--- a/e2e/specs/mcp-agent-marketplace.spec.ts
+++ b/e2e/specs/mcp-agent-marketplace.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { loginAndGoToChat } from './mcp-helpers';
 
+const isLocal = (process.env.E2E_BASE_URL || '').includes('localhost');
+
 test.describe('Agent Marketplace entry', () => {
+  test.skip(!isLocal, 'Agent Marketplace is not enabled in deployed librechat.<env>.yml interface config');
   test.beforeEach(async ({ page }) => {
     await loginAndGoToChat(page);
   });

--- a/e2e/specs/mcp-landing.spec.ts
+++ b/e2e/specs/mcp-landing.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from '@playwright/test';
 
+const isLocal = (process.env.E2E_BASE_URL || '').includes('localhost');
+
 test.describe('Landing page (login)', () => {
+  test.skip(!isLocal, 'Landing page tests assert the LibreChat login form; deployed envs use Azure Entra / OpenID');
   test.use({ storageState: { cookies: [], origins: [] } });
 
   test.beforeEach(async ({ page }) => {

--- a/e2e/specs/mcp-logout.spec.ts
+++ b/e2e/specs/mcp-logout.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { loginAndGoToChat } from './mcp-helpers';
 
+const isLocal = (process.env.E2E_BASE_URL || '').includes('localhost');
+
 test.describe('Logout', () => {
+  test.skip(!isLocal, 'Logout asserts redirect to LibreChat /login form; deployed envs sign out through Azure Entra');
   test('Log out menu item returns the user to /login', async ({ page }) => {
     await loginAndGoToChat(page);
     await page.getByTestId('nav-user').click();

--- a/e2e/specs/mcp-settings-account.spec.ts
+++ b/e2e/specs/mcp-settings-account.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
 import { closeSettingsDialog, loginAndGoToChat, openSettingsDialog } from './mcp-helpers';
 
+const isLocal = (process.env.E2E_BASE_URL || '').includes('localhost');
+
 test.describe('Settings dialog: Account tab', () => {
   test.beforeEach(async ({ page }) => {
     await loginAndGoToChat(page);
@@ -13,6 +15,7 @@ test.describe('Settings dialog: Account tab', () => {
   });
 
   test('shows Profile Picture and Two-Factor controls', async ({ page }) => {
+    test.skip(!isLocal, 'Profile Picture and Two-Factor controls are hidden in deployed envs where identity is managed by Azure Entra');
     const panel = page.getByRole('tabpanel');
     await expect(panel).toContainText(/Profile Picture/i);
     await expect(panel).toContainText(/Two-Factor Authentication/i);

--- a/e2e/specs/mcp-tools-dropdown.spec.ts
+++ b/e2e/specs/mcp-tools-dropdown.spec.ts
@@ -11,6 +11,8 @@ import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { loginAndGoToChat } from './mcp-helpers';
 
+const isLocal = (process.env.E2E_BASE_URL || '').includes('localhost');
+
 const TOOLS = ['File Search', 'Web Search', 'Artifacts'] as const;
 type ToolName = (typeof TOOLS)[number];
 
@@ -84,6 +86,7 @@ test.describe('Tools dropdown', () => {
   });
 
   test('clicking the Tools button opens the dropdown', async ({ page }) => {
+    test.skip(!isLocal, 'File Search / Web Search / Artifacts tools are not enabled in deployed librechat.<env>.yml config');
     await openToolsDropdown(page);
     for (const name of TOOLS) {
       await expect(page.getByRole('menuitem', { name: new RegExp(name) })).toBeVisible();
@@ -91,6 +94,7 @@ test.describe('Tools dropdown', () => {
   });
 
   test('dropdown contains exactly File Search, Web Search, and Artifacts', async ({ page }) => {
+    test.skip(!isLocal, 'File Search / Web Search / Artifacts tools are not enabled in deployed librechat.<env>.yml config');
     await openToolsDropdown(page);
 
     // The portal element ID literally contains a '/', which is illegal in CSS
@@ -119,6 +123,7 @@ test.describe('Tools dropdown', () => {
   });
 
   test('each item has a label and a description (Paychex enhancement)', async ({ page }) => {
+    test.skip(!isLocal, 'File Search / Web Search / Artifacts tools are not enabled in deployed librechat.<env>.yml config');
     await openToolsDropdown(page);
 
     const expectations: Record<ToolName, RegExp> = {


### PR DESCRIPTION
Mirrors the existing isLocal pattern used in mcp-{login-form,register-link, theme-toggle}.spec.ts. These specs assert behaviors that are unavailable or replaced in deployed environments and previously produced false failures when running against N2A/N1/prod.

- mcp-landing, mcp-logout: assert LibreChat email/password login form and '/login' redirect; deployed envs use Azure Entra OpenID and sign out through the IdP.
- mcp-agent-marketplace: Agent Marketplace is not enabled in the deployed librechat.<env>.yml interface config.
- mcp-settings-account 'Profile Picture and Two-Factor': identity is managed by Azure Entra under SSO; controls are hidden in the UI.
- mcp-tools-dropdown (3 tests): File Search / Web Search / Artifacts are not enabled in deployed librechat.<env>.yml config.

Local: 89 passed / 3 skipped / 0 failed (unchanged).
N2A:   73 passed / 19 skipped / 0 failed (was 73 / 10 / 9).

