### PR TITLE
Allow Paychex MCP domains

### DIFF
--- a/librechat.prod.yml
+++ b/librechat.prod.yml
@@ -78,6 +78,10 @@ mcpServers:
     chatMenu: false
     serverInstructions: "TAVILY SEARCH PROTOCOL: (1) Never use tavily_research tool unless the user explicitly includes '/deep-research' in their prompt. For all other queries, use tavily_search which has higher rate limits. If /deep-research is requested, use 'mini' model first, and only escalate to 'pro' if the task clearly requires broader multi-topic coverage. (2) If a search fails or returns errors, analyze the error message, modify the query or parameters, and retry with adjustments. "
     requiresOAuth: false
+mcpSettings:
+  allowedDomains:
+    - https://mcp.tavily.com
+    - '*.paychex.com'
 endpoints:
   azureOpenAI:
     # Endpoint-level configuration


### PR DESCRIPTION
## Summary
- Add MCP allowedDomains for Tavily so the existing configured Tavily MCP remains unaffected when allowlist mode is enabled
- Allow Paychex MCP hosts via '*.paychex.com' so admins can manually create Paychex-hosted MCP servers in the UI

## Validation
- Parsed librechat.prod.yml successfully