### PR TITLE
fix: resolve E2E ADFS authentication failures on N2A CI runners

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,6 +27,11 @@ on:
           - n2a
           - n1
           - prod
+      test_branch:
+        description: 'Branch to check out test code from (defaults to develop)'
+        required: false
+        default: 'develop'
+        type: string
 
 jobs:
   e2e:
@@ -56,7 +61,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: develop
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_branch || 'develop' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/e2e/setup/global-setup-ci.ts
+++ b/e2e/setup/global-setup-ci.ts
@@ -49,9 +49,12 @@ function isAdfsWiaPage(url: string): boolean {
 }
 
 function adfsFormsUrlFromWia(wiaUrl: string): string {
-  return wiaUrl
-    .replace('/adfs/ls/wia', '/adfs/ls/')
-    .replace(/LoginOptions%3D3/i, 'LoginOptions%3D1');
+  const url = new URL(wiaUrl);
+  // Switch to the forms-based endpoint
+  url.pathname = url.pathname.replace(/\/wia$/, '/');
+  // Remove the TLS/WIA device-auth hint so ADFS doesn't bounce back to WIA
+  url.searchParams.delete('deviceAuthenticationMethod');
+  return url.toString();
 }
 
 async function fillAdfsCredentials(page: Page, email: string, password: string, baseOrigin: string): Promise<void> {

--- a/e2e/setup/global-setup-ci.ts
+++ b/e2e/setup/global-setup-ci.ts
@@ -24,7 +24,12 @@ function isLocalhost(url: string): boolean {
   return parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
 }
 
-async function loginLocal(page: Page, baseUrl: string, email: string, password: string): Promise<void> {
+async function loginLocal(
+  page: Page,
+  baseUrl: string,
+  email: string,
+  password: string,
+): Promise<void> {
   await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 30000 });
 
   // Wait for the login form to render
@@ -57,19 +62,35 @@ function adfsFormsUrlFromWia(wiaUrl: string): string {
   return url.toString();
 }
 
-async function fillAdfsCredentials(page: Page, email: string, password: string, baseOrigin: string): Promise<void> {
-  const adfsUsername = email.split('@')[0];
-  const usernameInput = page.locator('#userNameInput, input[name="UserName"], input[name="username"]').first();
-  const passwordInput = page.locator('#passwordInput, input[name="Password"], input[name="password"], input[type="password"]').first();
-  const submitButton = page.locator('#submitButton, input[type="submit"], button[type="submit"]').first();
-
+async function fillAdfsCredentials(
+  page: Page,
+  email: string,
+  password: string,
+  baseOrigin: string,
+): Promise<void> {
   if (new URL(page.url()).origin === baseOrigin) {
     return;
   }
 
+  const adfsUsername = email.split('@')[0];
+  const usernameInput = page
+    .locator('#userNameInput, input[name="UserName"], input[name="username"]')
+    .first();
+  const passwordInput = page
+    .locator(
+      '#passwordInput, input[name="Password"], input[name="password"], input[type="password"]',
+    )
+    .first();
+  const submitButton = page
+    .locator('#submitButton, input[type="submit"], button[type="submit"]')
+    .first();
+
   if (isAdfsWiaPage(page.url())) {
     console.log('  ↪ ADFS attempted WIA — forcing forms-based login');
-    await page.goto(adfsFormsUrlFromWia(page.url()), { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await page.goto(adfsFormsUrlFromWia(page.url()), {
+      waitUntil: 'domcontentloaded',
+      timeout: 30000,
+    });
   }
 
   await usernameInput.waitFor({ state: 'visible', timeout: 30000 });
@@ -81,7 +102,12 @@ async function fillAdfsCredentials(page: Page, email: string, password: string, 
   await page.waitForURL((url) => url.origin === baseOrigin, { timeout: 30000 });
 }
 
-async function loginAzureAD(page: Page, baseUrl: string, email: string, password: string): Promise<void> {
+async function loginAzureAD(
+  page: Page,
+  baseUrl: string,
+  email: string,
+  password: string,
+): Promise<void> {
   await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 30000 });
 
   // Wait for the OpenID button to appear
@@ -104,10 +130,13 @@ async function loginAzureAD(page: Page, baseUrl: string, email: string, password
   //   b) ADFS WIA endpoint (domain-joined runners — must fall back to forms)
   //   c) Directly back to LibreChat (domain-joined machines via Kerberos/NTLM)
   const baseOrigin = new URL(baseUrl).origin;
-  await page.waitForURL((url) => {
-    const href = url.href.toLowerCase();
-    return href.includes('adfs') || href.includes('sts') || url.origin === baseOrigin;
-  }, { timeout: 30000, waitUntil: 'domcontentloaded' });
+  await page.waitForURL(
+    (url) => {
+      const href = url.href.toLowerCase();
+      return href.includes('adfs') || href.includes('sts') || url.origin === baseOrigin;
+    },
+    { timeout: 30000, waitUntil: 'domcontentloaded' },
+  );
 
   const currentUrl = page.url();
   if (currentUrl.includes('adfs') || currentUrl.includes('sts')) {
@@ -142,7 +171,7 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
   // the username/password form that headless automation requires.
   const browser = await chromium.launch({
     headless: true,
-    args: ['--auth-server-whitelist="_"'],
+    args: ['--auth-server-allowlist="_"'],
   });
   const context = await browser.newContext({ ignoreHTTPSErrors: true });
   const page = await context.newPage();

--- a/e2e/setup/global-setup-ci.ts
+++ b/e2e/setup/global-setup-ci.ts
@@ -44,6 +44,40 @@ async function loginLocal(page: Page, baseUrl: string, email: string, password: 
   console.log('  ✓ Successfully authenticated locally — LibreChat loaded');
 }
 
+function isAdfsWiaPage(url: string): boolean {
+  return url.includes('/adfs/ls/wia') || url.includes('deviceAuthenticationMethod');
+}
+
+function adfsFormsUrlFromWia(wiaUrl: string): string {
+  return wiaUrl
+    .replace('/adfs/ls/wia', '/adfs/ls/')
+    .replace(/LoginOptions%3D3/i, 'LoginOptions%3D1');
+}
+
+async function fillAdfsCredentials(page: Page, email: string, password: string, baseOrigin: string): Promise<void> {
+  const adfsUsername = email.split('@')[0];
+  const usernameInput = page.locator('#userNameInput, input[name="UserName"], input[name="username"]').first();
+  const passwordInput = page.locator('#passwordInput, input[name="Password"], input[name="password"], input[type="password"]').first();
+  const submitButton = page.locator('#submitButton, input[type="submit"], button[type="submit"]').first();
+
+  if (new URL(page.url()).origin === baseOrigin) {
+    return;
+  }
+
+  if (isAdfsWiaPage(page.url())) {
+    console.log('  ↪ ADFS attempted WIA — forcing forms-based login');
+    await page.goto(adfsFormsUrlFromWia(page.url()), { waitUntil: 'domcontentloaded', timeout: 30000 });
+  }
+
+  await usernameInput.waitFor({ state: 'visible', timeout: 30000 });
+  await usernameInput.fill(adfsUsername);
+  await passwordInput.fill(password);
+  await submitButton.click();
+  console.log('  ✓ Submitted credentials on ADFS');
+
+  await page.waitForURL((url) => url.origin === baseOrigin, { timeout: 30000 });
+}
+
 async function loginAzureAD(page: Page, baseUrl: string, email: string, password: string): Promise<void> {
   await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 30000 });
 
@@ -64,7 +98,8 @@ async function loginAzureAD(page: Page, baseUrl: string, email: string, password
 
   // After Microsoft redirects, we may land on:
   //   a) ADFS form (CI runners / non-domain-joined machines / incognito)
-  //   b) Directly back to LibreChat (domain-joined machines via Kerberos/NTLM)
+  //   b) ADFS WIA endpoint (domain-joined runners — must fall back to forms)
+  //   c) Directly back to LibreChat (domain-joined machines via Kerberos/NTLM)
   const baseOrigin = new URL(baseUrl).origin;
   await page.waitForURL((url) => {
     const href = url.href.toLowerCase();
@@ -74,22 +109,7 @@ async function loginAzureAD(page: Page, baseUrl: string, email: string, password
   const currentUrl = page.url();
   if (currentUrl.includes('adfs') || currentUrl.includes('sts')) {
     console.log('  ✓ Redirected to ADFS — filling credentials');
-
-    // ADFS expects just the username (without @domain)
-    const adfsUsername = email.split('@')[0];
-
-    const usernameInput = page.locator('#userNameInput, input[name="UserName"], input[name="username"]').first();
-    const passwordInput = page.locator('#passwordInput, input[name="Password"], input[name="password"], input[type="password"]').first();
-    const submitButton = page.locator('#submitButton, input[type="submit"], button[type="submit"]').first();
-
-    await usernameInput.waitFor({ state: 'visible', timeout: 10000 });
-    await usernameInput.fill(adfsUsername);
-    await passwordInput.fill(password);
-    await submitButton.click();
-    console.log('  ✓ Submitted credentials on ADFS');
-
-    // Wait for redirect back to LibreChat
-    await page.waitForURL((url) => url.origin === baseOrigin, { timeout: 30000 });
+    await fillAdfsCredentials(page, email, password, baseOrigin);
   } else {
     console.log('  ✓ Auto-authenticated (Windows Integrated Auth) — skipped ADFS form');
   }
@@ -114,11 +134,13 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
   const method = useLocal ? 'local email/password' : 'Azure AD';
   console.log(`🧪 Global Setup: authenticating ${USERNAME} against ${BASE_URL} (${method})`);
 
-  // On domain-joined Windows machines, Chromium auto-negotiates Kerberos
-  // regardless of launch flags. Locally this authenticates as the developer;
-  // on CI runners (not domain-joined) the ADFS form will appear and the
-  // service account credentials will be used.
-  const browser = await chromium.launch({ headless: true });
+  // Prevent Chromium from auto-negotiating Kerberos/NTLM with ADFS. Without this,
+  // domain-joined CI runners land on /adfs/ls/wia (integrated auth) instead of
+  // the username/password form that headless automation requires.
+  const browser = await chromium.launch({
+    headless: true,
+    args: ['--auth-server-whitelist="_"'],
+  });
   const context = await browser.newContext({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
 


### PR DESCRIPTION
**Problem**

The E2E smoke tests were consistently failing during the global setup authentication step. After Microsoft login redirected to ADFS, the CI runner was landing on `/adfs/ls/wia?...&deviceAuthenticationMethod=TlsHandler` (Windows Integrated Authentication) instead of the username/password form. The setup code waited for `#userNameInput`, which never renders on the WIA page, and timed out.

Two compounding issues:
1. Chromium was auto-negotiating Kerberos/NTLM because no suppression flag was set, which caused ADFS to route to WIA instead of forms-based auth.
2. The fallback that redirected from the WIA URL to the forms URL left `deviceAuthenticationMethod=TlsHandler` as a query parameter, which could cause ADFS to bounce back to WIA again.

Additionally, the e2e-tests.yml workflow hardcoded `ref: develop` in the checkout step, making it impossible to run tests against a branch before it was merged to `develop`.

**Changes**

- global-setup-ci.ts
  - Launch Chromium with `--auth-server-whitelist="_"` to prevent NTLM/Kerberos auto-negotiation — ADFS now routes to forms-based login on CI runners
  - Add `isAdfsWiaPage()` to detect WIA redirects (catches both `/adfs/ls/wia` path and `deviceAuthenticationMethod` query param)
  - Add `fillAdfsCredentials()` with a `adfsFormsUrlFromWia()` fallback that properly strips `deviceAuthenticationMethod` using URL parsing before navigating to the forms endpoint
  - Raise the username input `waitFor` timeout from 10 s → 30 s

- e2e-tests.yml
  - Add optional `test_branch` input to `workflow_dispatch` (defaults to `develop`)
  - Checkout step uses `test_branch` when manually dispatched, `develop` for all automated triggers
  - Enables running E2E tests against a feature/upstream branch deployed to N2A without first merging to `develop`

**Testing**

Automated and nightly runs are unaffected — they still check out `develop`. To test a branch manually: dispatch E2E Tests, set environment = `n2a`, set `test_branch` to your branch name.