### PR TITLE
Add corp SNOW MCP OBO readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1017,6 +1017,9 @@ OPENWEATHER_API_KEY=
 # Treat 401/403 responses as OAuth requirement when no oauth metadata found
 # MCP_OAUTH_ON_AUTH_ERROR=true
 
+# Scopes requested for the Corp SNOW ServiceNow MCP OBO token exchange
+# SERVICENOW_MCP_OBO_SCOPES=api://servicenow-mcp-app-id/Mcp.Tools.ReadWrite
+
 # Timeout for OAuth detection requests in milliseconds
 # MCP_OAUTH_DETECTION_TIMEOUT=5000
 

--- a/az_container_app_definitions/n1_container_app_definition.yml
+++ b/az_container_app_definitions/n1_container_app_definition.yml
@@ -67,6 +67,9 @@ properties:
       - name: tavily-api-key
         keyVaultUrl: https://kv-pyxplayai-n1-001.vault.azure.net/secrets/N1-TAVILY-API-KEY
         identity: system
+      - name: servicenow-mcp-obo-scopes
+        keyVaultUrl: https://kv-pyxplayai-n1-001.vault.azure.net/secrets/N1-SERVICENOW-MCP-OBO-SCOPES
+        identity: system
     activeRevisionsMode: Single
     ingress:
       fqdn: conpaichateastusn1001.wittysmoke-fd7d7688.eastus.azurecontainerapps.io
@@ -113,7 +116,9 @@ properties:
           - name: MONGO_URI
             secretRef: mongo-connection-string
           - name: OPENID_SCOPE
-            value: openid profile email
+            value: api://89b0e6f6-6b38-4016-8f98-13fd6af9b589/.default openid profile email offline_access
+          - name: OPENID_REUSE_TOKENS
+            value: 'true'
           - name: OPENID_SESSION_SECRET
             secretRef: openid-session-secret
           - name: OPENID_ISSUER
@@ -136,6 +141,8 @@ properties:
             secretRef: maas-api-key
           - name: TAVILY_API_KEY
             secretRef: tavily-api-key
+          - name: SERVICENOW_MCP_OBO_SCOPES
+            secretRef: servicenow-mcp-obo-scopes
           - name: ALLOW_REGISTRATION
             value: FALSE
           - name: ALLOW_EMAIL_LOGIN

--- a/az_container_app_definitions/n2a_container_app_definition.yml
+++ b/az_container_app_definitions/n2a_container_app_definition.yml
@@ -59,6 +59,9 @@ properties:
       - name: tavily-api-key
         keyVaultUrl: https://kv-pyxplayai-n2a-001.vault.azure.net/secrets/N2A-TAVILY-API-KEY
         identity: system
+      - name: servicenow-mcp-obo-scopes
+        keyVaultUrl: https://kv-pyxplayai-n2a-001.vault.azure.net/secrets/N2A-SERVICENOW-MCP-OBO-SCOPES
+        identity: system
     activeRevisionsMode: Single
     ingress:
       external: true
@@ -167,6 +170,8 @@ properties:
             value: TRUE
           - name: TAVILY_API_KEY
             secretRef: tavily-api-key
+          - name: SERVICENOW_MCP_OBO_SCOPES
+            secretRef: servicenow-mcp-obo-scopes
           - name: NODE_OPTIONS
             value: --max-old-space-size=4096
           - name: BAN_VIOLATIONS

--- a/az_container_app_definitions/prod_container_app_definition.yml
+++ b/az_container_app_definitions/prod_container_app_definition.yml
@@ -37,6 +37,9 @@ properties:
       - name: tavily-api-key
         keyVaultUrl: https://kv-pyxplayai-prod-001.vault.azure.net/secrets/PROD-TAVILY-API-KEY
         identity: system
+      - name: servicenow-mcp-obo-scopes
+        keyVaultUrl: https://kv-pyxplayai-prod-001.vault.azure.net/secrets/PROD-SERVICENOW-MCP-OBO-SCOPES
+        identity: system
     activeRevisionsMode: single
     registries:
       - server: conpaychexaiprod001.azurecr.io
@@ -74,7 +77,9 @@ properties:
         - name: MONGO_URI
           secretRef: mongo-connection-string
         - name: OPENID_SCOPE
-          value: "openid profile email"
+          value: "api://a641b00b-5902-413c-b5e7-9d5b8cb57445/.default openid profile email offline_access"
+        - name: OPENID_REUSE_TOKENS
+          value: 'true'
         - name: OPENID_SESSION_SECRET
           secretRef: openid-session-secret
         - name: OPENID_ISSUER
@@ -97,6 +102,8 @@ properties:
           secretRef: maas-api-key
         - name: TAVILY_API_KEY
           secretRef: tavily-api-key
+        - name: SERVICENOW_MCP_OBO_SCOPES
+          secretRef: servicenow-mcp-obo-scopes
         - name: ALLOW_REGISTRATION
           value: FALSE
         - name: ALLOW_EMAIL_LOGIN

--- a/librechat.n1.yml
+++ b/librechat.n1.yml
@@ -71,6 +71,14 @@ modelSpecs:
         endpoint: "Claude Sonnet 4.5"
         model: claude-sonnet-4-5
 mcpServers:
+  corp-intose-mcpservicenow-mcp-pyx:
+    title: Corp SNOW ServiceNow
+    type: streamable-http
+    url: https://corp-intose-mcpservicenow-mcp-pyx.n1-lb.paychex.com/mcp
+    obo:
+      scopes: ${SERVICENOW_MCP_OBO_SCOPES}
+    startup: false
+    requiresOAuth: false
   Internet Search (Tavily):
     type: streamable-http
     url: https://mcp.tavily.com/mcp/

--- a/librechat.n2a.yml
+++ b/librechat.n2a.yml
@@ -71,6 +71,14 @@ modelSpecs:
         endpoint: "Claude Sonnet 4.5"
         model: claude-sonnet-4-5
 mcpServers:
+  corp-intose-mcpservicenow-mcp-pyx:
+    title: Corp SNOW ServiceNow
+    type: streamable-http
+    url: https://corp-intose-mcpservicenow-mcp-pyx.n1-lb.paychex.com/mcp
+    obo:
+      scopes: ${SERVICENOW_MCP_OBO_SCOPES}
+    startup: false
+    requiresOAuth: false
   Internet Search (Tavily):
     type: streamable-http
     url: https://mcp.tavily.com/mcp/

--- a/librechat.prod.yml
+++ b/librechat.prod.yml
@@ -69,6 +69,14 @@ modelSpecs:
         endpoint: "Claude Sonnet 4.5"
         model: claude-sonnet-4-5
 mcpServers:
+  corp-intose-mcpservicenow-mcp-pyx:
+    title: Corp SNOW ServiceNow
+    type: streamable-http
+    url: https://corp-intose-mcpservicenow-mcp-pyx.n1-lb.paychex.com/mcp
+    obo:
+      scopes: ${SERVICENOW_MCP_OBO_SCOPES}
+    startup: false
+    requiresOAuth: false
   Internet Search (Tavily):
     type: streamable-http
     url: https://mcp.tavily.com/mcp/

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -444,7 +444,7 @@ Please follow these instructions when using tools from the respective MCP server
         'headers' in currentOptions ? { ...(currentOptions.headers || {}) } : {};
 
       /** Refresh OBO token on each tool call to ensure it's current */
-      const oboConfig = rawConfig.obo;
+      const oboConfig = currentOptions.obo;
       if (oboConfig && oboTokenResolver && user) {
         const oboTrusted = oboTrustChecker
           ? await oboTrustChecker({

--- a/packages/api/src/mcp/__tests__/mcp.spec.ts
+++ b/packages/api/src/mcp/__tests__/mcp.spec.ts
@@ -1,5 +1,6 @@
 import {
   MCPOptions,
+  MCPServerUserInputSchema,
   StdioOptionsSchema,
   StreamableHTTPOptionsSchema,
 } from 'librechat-data-provider';
@@ -186,6 +187,20 @@ describe('Environment Variable Extraction (MCP)', () => {
 
       expect(() => StreamableHTTPOptionsSchema.parse(options)).toThrow();
     });
+
+    it('should reject environment variables in user-managed OBO scopes', () => {
+      const options = {
+        type: 'streamable-http',
+        url: 'https://example.com/api',
+        obo: {
+          scopes: '${SERVICENOW_MCP_OBO_SCOPES}',
+        },
+      };
+
+      expect(() => MCPServerUserInputSchema.parse(options)).toThrow(
+        'Environment variable references are not allowed in OBO scopes',
+      );
+    });
   });
 
   describe('processMCPEnv', () => {
@@ -348,6 +363,40 @@ describe('Environment Variable Extraction (MCP)', () => {
 
       expect('proxy' in result && result.proxy).toBe('http://proxy.example.com:8080');
       delete process.env.MCP_PROXY_URL;
+    });
+
+    it('should process environment variables in OBO scopes for trusted configs', () => {
+      process.env.SERVICENOW_MCP_OBO_SCOPES = 'api://servicenow-mcp/Mcp.Tools.ReadWrite';
+      const options: MCPOptions = {
+        type: 'streamable-http',
+        url: 'https://example.com/mcp',
+        obo: {
+          scopes: '${SERVICENOW_MCP_OBO_SCOPES}',
+        },
+      };
+
+      const result = processMCPEnv({ options });
+
+      expect('obo' in result && result.obo?.scopes).toBe(
+        'api://servicenow-mcp/Mcp.Tools.ReadWrite',
+      );
+      delete process.env.SERVICENOW_MCP_OBO_SCOPES;
+    });
+
+    it('should not process environment variables in OBO scopes for DB-sourced configs', () => {
+      process.env.SERVICENOW_MCP_OBO_SCOPES = 'api://servicenow-mcp/Mcp.Tools.ReadWrite';
+      const options = {
+        type: 'streamable-http' as const,
+        url: 'https://example.com/mcp',
+        obo: {
+          scopes: '${SERVICENOW_MCP_OBO_SCOPES}',
+        },
+      };
+
+      const result = processMCPEnv({ options: options as unknown as MCPOptions, dbSourced: true });
+
+      expect('obo' in result && result.obo?.scopes).toBe('${SERVICENOW_MCP_OBO_SCOPES}');
+      delete process.env.SERVICENOW_MCP_OBO_SCOPES;
     });
 
     it('should maintain streamable-http type in processed options', () => {

--- a/packages/api/src/mcp/oauth/obo.spec.ts
+++ b/packages/api/src/mcp/oauth/obo.spec.ts
@@ -46,6 +46,20 @@ describe('resolveOboToken', () => {
     jest.clearAllMocks();
   });
 
+  it('should throw when scopes are empty or unresolved', async () => {
+    mockExtractOpenIDTokenInfo.mockReturnValue({ accessToken: 'federated-access-token' });
+    mockIsOpenIDTokenValid.mockReturnValue(true);
+
+    await expect(
+      resolveOboToken(mockUser as IUser, { scopes: '${SERVICENOW_MCP_OBO_SCOPES}' }, mockResolver),
+    ).rejects.toMatchObject({
+      reason: 'invalid_scopes',
+      retryable: false,
+      userMessage: 'OBO scopes are not configured for this MCP server.',
+    });
+    expect(mockResolver).not.toHaveBeenCalled();
+  });
+
   it('should throw when user has no valid OpenID token info', async () => {
     mockExtractOpenIDTokenInfo.mockReturnValue(null);
 

--- a/packages/api/src/mcp/oauth/obo.ts
+++ b/packages/api/src/mcp/oauth/obo.ts
@@ -20,6 +20,7 @@ export type OboTokenResolver = (
 ) => Promise<{ access_token: string; expires_in?: number }>;
 
 export type OboTokenResolutionReason =
+  | 'invalid_scopes'
   | 'missing_upstream_token'
   | 'missing_upstream_access_token'
   | 'empty_exchange_response'
@@ -27,6 +28,7 @@ export type OboTokenResolutionReason =
 
 const RETRYABLE_OBO_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
 const RETRYABLE_OBO_ERROR_CODES = new Set(['ETIMEDOUT', 'ECONNRESET', 'EAI_AGAIN', 'ENOTFOUND']);
+const UNRESOLVED_ENV_VAR_PATTERN = /\$\{[^}]+\}/;
 
 function getErrorStatus(error: unknown): number | undefined {
   if (!error || typeof error !== 'object') {
@@ -122,6 +124,15 @@ export async function resolveOboToken(
   oboConfig: OboConfig,
   oboTokenResolver: OboTokenResolver,
 ): Promise<MCPOAuthTokens> {
+  const scopes = oboConfig.scopes?.trim();
+  if (!scopes || UNRESOLVED_ENV_VAR_PATTERN.test(scopes)) {
+    logger.warn('[OBO] OBO scopes are empty or contain unresolved environment variables');
+    throw new OboTokenResolutionError(
+      'invalid_scopes',
+      'OBO scopes are not configured for this MCP server.',
+    );
+  }
+
   const tokenInfo = extractOpenIDTokenInfo(user);
   if (!tokenInfo || !isOpenIDTokenValid(tokenInfo)) {
     logger.warn(
@@ -142,7 +153,7 @@ export async function resolveOboToken(
   }
 
   try {
-    const response = await oboTokenResolver(user, tokenInfo.accessToken, oboConfig.scopes, true);
+    const response = await oboTokenResolver(user, tokenInfo.accessToken, scopes, true);
 
     if (!response?.access_token) {
       logger.warn('[OBO] Token exchange did not return an access token');

--- a/packages/api/src/mcp/registry/MCPServerInspector.ts
+++ b/packages/api/src/mcp/registry/MCPServerInspector.ts
@@ -125,6 +125,10 @@ export class MCPServerInspector {
   private async detectOAuth(): Promise<void> {
     if (this.config.requiresOAuth != null) return;
     if (hasRuntimeUrlPlaceholders(this.config)) return;
+    if (this.config.obo) {
+      this.config.requiresOAuth = false;
+      return;
+    }
     if (this.config.url == null || this.config.startup === false) {
       this.config.requiresOAuth = false;
       return;

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -432,6 +432,13 @@ export function processMCPEnv(params: {
     newObj.oauth = processedOAuth;
   }
 
+  if ('obo' in newObj && newObj.obo) {
+    newObj.obo = {
+      ...newObj.obo,
+      scopes: processAdminValue(newObj.obo.scopes, dbSourced),
+    };
+  }
+
   return newObj;
 }
 

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -151,7 +151,19 @@ const UserOAuthOptionsSchema = OAuthOptionsBaseSchema.omit({
 
 const OboOptionsSchema = z.object({
   /** Scopes to request for the downstream MCP server (e.g., "api://<client-id>/Mcp.Tools.ReadWrite") */
-  scopes: z.string().min(1),
+  scopes: z
+    .string()
+    .transform((val) => extractEnvVariable(val))
+    .pipe(z.string().min(1)),
+});
+
+const UserOboOptionsSchema = z.object({
+  scopes: z
+    .string()
+    .min(1)
+    .refine((val) => !envVarPattern.test(val), {
+      message: 'Environment variable references are not allowed in OBO scopes',
+    }),
 });
 
 const BaseOptionsSchema = z.object({
@@ -434,10 +446,12 @@ export const MCPServerUserInputSchema = z.union([
     url: userUrlSchema(isWsProtocol, 'WebSocket URL must use ws:// or wss://'),
   }),
   userManagedServerFields(SSEOptionsSchema).extend({
+    obo: UserOboOptionsSchema.optional(),
     proxy: z.never().optional(),
     url: userUrlSchema(isHttpProtocol, 'SSE URL must use http:// or https://'),
   }),
   userManagedServerFields(StreamableHTTPOptionsSchema).extend({
+    obo: UserOboOptionsSchema.optional(),
     proxy: z.never().optional(),
     url: userUrlSchema(isHttpProtocol, 'Streamable HTTP URL must use http:// or https://'),
   }),


### PR DESCRIPTION
## Summary\n- add the corp ServiceNow MCP server to n1, n2a, and prod LibreChat configs with streamable-http OBO token exchange\n- wire SERVICENOW_MCP_OBO_SCOPES and OpenID token reuse prerequisites into Azure Container App definitions\n- resolve OBO scopes from trusted env-backed configs, reject unresolved scopes, and avoid treating OBO servers as MCP OAuth servers during inspection\n\n## Validation\n- npm run build:data-provider\n- npm run build:data-schemas\n- cd packages/api && npx jest src/mcp/oauth/obo.spec.ts src/mcp/__tests__/mcp.spec.ts src/mcp/__tests__/utils.test.ts src/mcp/__tests__/MCPManager.test.ts --runInBand\n- npm run build:api\n- cd api && npx jest server/services/OboTokenService.spec.js server/services/__tests__/MCP.spec.js --runInBand\n- ./scripts/verify-paychex-customizations.sh\n- parsed changed LibreChat and Azure YAML files with js-yaml