### PR TITLE
Whitelist OSSSTATUS MCP host

### DIFF
--- a/librechat.n1.yml
+++ b/librechat.n1.yml
@@ -84,6 +84,7 @@ mcpSettings:
   allowedDomains:
     - https://mcp.tavily.com
     - '*.paychex.com'
+    - https://paycm56stg-idwtpqsqijlw-ia.integration.us-ashburn-1.ocp.oraclecloud.com
 endpoints:
   azureOpenAI:
     # Endpoint-level configuration

--- a/librechat.n2a.yml
+++ b/librechat.n2a.yml
@@ -84,6 +84,7 @@ mcpSettings:
   allowedDomains:
     - https://mcp.tavily.com
     - '*.paychex.com'
+    - https://paycm56stg-idwtpqsqijlw-ia.integration.us-ashburn-1.ocp.oraclecloud.com
 endpoints:
   azureOpenAI:
     # Endpoint-level configuration

--- a/librechat.prod.yml
+++ b/librechat.prod.yml
@@ -83,6 +83,7 @@ mcpSettings:
   allowedDomains:
     - https://mcp.tavily.com
     - '*.paychex.com'
+    - https://paycm56stg-idwtpqsqijlw-ia.integration.us-ashburn-1.ocp.oraclecloud.com
 endpoints:
   azureOpenAI:
     # Endpoint-level configuration


### PR DESCRIPTION
## Summary\n- Add the OSSSTATUS MCP host to MCP allowed domains for N1, N2A, and prod LibreChat configs\n- Whitelist only the main host URL, not the full MCP path\n\n## Validation\n- Parsed all updated YAML configs\n- Ran git diff --check