### PR TITLE
chore: removing nightly sync workflow cron as its no longer used

### DIFF
--- a/.github/workflows/sync_tags.yml
+++ b/.github/workflows/sync_tags.yml
@@ -1,8 +1,6 @@
 name: Sync Tags
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/sync_tags.yml` workflow by removing the scheduled nightly run. The workflow can now only be triggered manually.