### PR TITLE
Fix agent selection persistence on new chat

### DIFF
--- a/client/src/hooks/useNewConvo.ts
+++ b/client/src/hooks/useNewConvo.ts
@@ -32,6 +32,7 @@ import {
   getModelSpecPreset,
   hasModelSelection,
   buildDefaultConvo,
+  hasStoredConversationSelection,
   logger,
 } from '~/utils';
 import { useDeleteFilesMutation, useGetEndpointsQuery, useGetStartupConfig } from '~/data-provider';
@@ -95,9 +96,7 @@ const useNewConvo = (index = 0) => {
           storedSetup && typeof storedSetup === 'object' && Object.keys(storedSetup).length > 0
             ? (storedSetup as TConversation)
             : null;
-        const hasStoredModelSelection = Boolean(
-          storedConversation?.model ?? (storedConversation as Record<string, unknown>)?.agentOptions,
-        );
+        const hasStoredSelection = hasStoredConversationSelection(storedConversation);
         const buildDefaultConversation = (endpoint === null || buildDefault) ?? false;
         const hasExplicitChatProjectId = Object.prototype.hasOwnProperty.call(
           conversation,
@@ -113,20 +112,18 @@ const useNewConvo = (index = 0) => {
               (preset.presetId && preset.presetId === defaultPreset.presetId)),
         );
 
-        // Don't use the default preset if user has a stored model selection
+        // Don't use the default preset if user has a stored model or agent selection
         const shouldUseDefaultPreset = Boolean(
           defaultPreset &&
             !preset &&
             (defaultPreset.endpoint === endpoint || !endpoint) &&
             buildDefaultConversation &&
-            !hasStoredModelSelection,
+            !hasStoredSelection,
         );
 
-        // If the preset is the default spec and user has stored model, prefer stored conversation
+        // If the preset is the default spec and user has a stored selection, prefer stored conversation
         const effectivePreset =
-          isDefaultSpecPreset && hasStoredModelSelection && buildDefaultConversation
-            ? null
-            : preset;
+          isDefaultSpecPreset && hasStoredSelection && buildDefaultConversation ? null : preset;
 
         const appliedPreset: Partial<TPreset> | null = shouldUseDefaultPreset
           ? defaultPreset

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -12,6 +12,7 @@ import {
   processValidSettings,
   getDefaultModelSpec,
   getModelSpecPreset,
+  hasStoredConversationSelection,
   isNotFoundError,
   logger,
   clearMessagesCache,
@@ -175,10 +176,8 @@ export default function ChatRoute() {
         storedSetup && typeof storedSetup === 'object' && Object.keys(storedSetup).length > 0
           ? storedSetup
           : null;
-      const hasStoredModelSelection = Boolean(
-        storedConvo?.model ?? (storedConvo as Record<string, unknown>)?.agentOptions,
-      );
-      const activePreset = hasStoredModelSelection ? undefined : specPreset;
+      const hasStoredSelection = hasStoredConversationSelection(storedConvo);
+      const activePreset = hasStoredSelection ? undefined : specPreset;
 
       const queryParams: Record<string, string> = {};
       searchParams.forEach((value, key) => {

--- a/client/src/utils/endpoints.spec.ts
+++ b/client/src/utils/endpoints.spec.ts
@@ -1,6 +1,11 @@
-import { EModelEndpoint, getEndpointField } from 'librechat-data-provider';
+import { Constants, EModelEndpoint, getEndpointField } from 'librechat-data-provider';
 import type { TEndpointsConfig, TConfig } from 'librechat-data-provider';
-import { getAvailableEndpoints, getEndpointsFilter, mapEndpoints } from './endpoints';
+import {
+  getAvailableEndpoints,
+  getEndpointsFilter,
+  hasStoredConversationSelection,
+  mapEndpoints,
+} from './endpoints';
 
 const mockEndpointsConfig: TEndpointsConfig = {
   [EModelEndpoint.openAI]: { type: undefined, iconURL: 'openAI_icon.png', order: 0 },
@@ -81,5 +86,55 @@ describe('mapEndpoints', () => {
   it('returns sorted available endpoints', () => {
     const expectedOrder = [EModelEndpoint.openAI, EModelEndpoint.google, 'Mistral'];
     expect(mapEndpoints(mockEndpointsConfig)).toEqual(expectedOrder);
+  });
+});
+
+describe('hasStoredConversationSelection', () => {
+  it('returns false without a stored conversation', () => {
+    expect(hasStoredConversationSelection(null)).toBe(false);
+    expect(hasStoredConversationSelection({})).toBe(false);
+  });
+
+  it('detects a stored model selection', () => {
+    expect(
+      hasStoredConversationSelection({ endpoint: EModelEndpoint.openAI, model: 'gpt-5.4' }),
+    ).toBe(true);
+  });
+
+  it('detects a stored nested agent model selection', () => {
+    expect(
+      hasStoredConversationSelection({
+        endpoint: EModelEndpoint.openAI,
+        agentOptions: { model: 'gpt-5.4' },
+      }),
+    ).toBe(true);
+  });
+
+  it('detects a stored saved agent selection without a model', () => {
+    expect(
+      hasStoredConversationSelection({
+        endpoint: EModelEndpoint.agents,
+        agent_id: 'agent_123',
+      }),
+    ).toBe(true);
+  });
+
+  it('detects a stored saved agent selection with an empty model', () => {
+    expect(
+      hasStoredConversationSelection({
+        endpoint: EModelEndpoint.agents,
+        model: '',
+        agent_id: 'agent_123',
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores ephemeral agent ids as stored agent selections', () => {
+    expect(
+      hasStoredConversationSelection({
+        endpoint: EModelEndpoint.agents,
+        agent_id: Constants.EPHEMERAL_AGENT_ID.toString(),
+      }),
+    ).toBe(false);
   });
 });

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -91,6 +91,12 @@ export function mapEndpoints(endpointsConfig: t.TEndpointsConfig) {
 
 const firstLocalConvoKey = LocalStorageKeys.LAST_CONVO_SETUP + '_0';
 
+type StoredConversationSelection = Partial<t.TConversation> & {
+  agentOptions?: {
+    model?: string | null;
+  } | null;
+};
+
 /**
  * Ensures the last selected model stays up to date, as conversation may
  * update without updating last convo setup when same endpoint */
@@ -119,6 +125,23 @@ export function updateLastSelectedModel({
   );
   lastSelectedModels[endpoint] = model;
   localStorage.setItem(LocalStorageKeys.LAST_MODEL, JSON.stringify(lastSelectedModels));
+}
+
+export function hasStoredConversationSelection(
+  conversation?: StoredConversationSelection | null,
+): boolean {
+  if (!conversation) {
+    return false;
+  }
+
+  const hasStoredModelSelection = Boolean(conversation.model ?? conversation.agentOptions);
+  const hasStoredAgentSelection = Boolean(
+    isAgentsEndpoint(conversation.endpoint) &&
+      conversation.agent_id &&
+      !isEphemeralAgentId(conversation.agent_id),
+  );
+
+  return hasStoredModelSelection || hasStoredAgentSelection;
 }
 
 interface ConversationInitParams {


### PR DESCRIPTION
## Summary
- Treat saved agent selections as stored conversation selections when starting a new chat
- Preserve existing model/default preset behavior for model selections and ephemeral agents
- Add endpoint utility coverage for model, nested agent model, saved agent, and ephemeral agent cases

## Validation
- npm run build:data-provider
- npm run build:client-package
- cd client && ../node_modules/.bin/jest src/utils/endpoints.spec.ts --runInBand --watch=false --coverage=false
- cd client && npm run typecheck -- --pretty false