### PR TITLE
Fix Prompt Catalog deep links after 0.8.7

### DIFF
--- a/client/src/hooks/Input/useQueryParams.spec.ts
+++ b/client/src/hooks/Input/useQueryParams.spec.ts
@@ -18,13 +18,16 @@ jest.mock('~/store', () => ({
 }));
 
 import { renderHook, act } from '@testing-library/react';
+import { useToastContext } from '@librechat/client';
 import { useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
+import { QueryKeys } from 'librechat-data-provider';
 import useQueryParams from './useQueryParams';
 import { useChatContext, useChatFormContext } from '~/Providers';
 import useSubmitMessage from '~/hooks/Messages/useSubmitMessage';
 import useDefaultConvo from '~/hooks/Conversations/useDefaultConvo';
+import { startupConfigKey } from '~/data-provider';
 import store from '~/store';
 
 // Other mocks
@@ -35,6 +38,10 @@ jest.mock('react-router-dom', () => ({
 jest.mock('@tanstack/react-query', () => ({
   useQueryClient: jest.fn(),
   useQuery: jest.fn(),
+}));
+
+jest.mock('@librechat/client', () => ({
+  useToastContext: jest.fn(),
 }));
 
 jest.mock('~/Providers', () => ({
@@ -128,6 +135,7 @@ describe('useQueryParams', () => {
   // Setup common mocks before each test
   beforeEach(() => {
     jest.useFakeTimers();
+    global.fetch = jest.fn() as unknown as typeof fetch;
 
     // Reset mock for window.history.replaceState
     jest.spyOn(window.history, 'replaceState').mockClear();
@@ -146,10 +154,10 @@ describe('useQueryParams', () => {
 
     const mockQueryClient = {
       getQueryData: jest.fn().mockImplementation((key) => {
-        if (key === 'startupConfig') {
+        if (JSON.stringify(key) === JSON.stringify(startupConfigKey(true))) {
           return { modelSpecs: { list: [] } };
         }
-        if (key === 'endpoints') {
+        if (JSON.stringify(key) === JSON.stringify([QueryKeys.endpoints])) {
           return {};
         }
         return null;
@@ -189,8 +197,10 @@ describe('useQueryParams', () => {
     const { useAuthContext } = jest.requireMock('~/hooks/AuthContext');
     (useAuthContext as jest.Mock).mockReturnValue({
       user: { id: 'test-user-id' },
+      token: 'test-token',
       isAuthenticated: true,
     });
+    (useToastContext as jest.Mock).mockReturnValue({ showToast: jest.fn() });
   });
 
   afterEach(() => {
@@ -307,6 +317,121 @@ describe('useQueryParams', () => {
     );
     expect(mockHandleSubmit).toHaveBeenCalled();
     expect(mockSubmitMessage).toHaveBeenCalled();
+  });
+
+  it('should resolve PromptHub-style Prompt Catalog inserts using the authenticated startup config key', async () => {
+    const mockSetValue = jest.fn();
+    const mockSetSearchParams = jest.fn();
+    const mockGetQueryData = jest.fn().mockImplementation((key) => {
+      if (JSON.stringify(key) === JSON.stringify(startupConfigKey(true))) {
+        return { modelSpecs: { list: [] } };
+      }
+      if (JSON.stringify(key) === JSON.stringify([QueryKeys.endpoints])) {
+        return {};
+      }
+      return null;
+    });
+    const mockTextAreaRef = {
+      current: {
+        focus: jest.fn(),
+        setSelectionRange: jest.fn(),
+      } as unknown as HTMLTextAreaElement,
+    };
+
+    (useChatFormContext as jest.Mock).mockReturnValue({
+      setValue: mockSetValue,
+      getValues: jest.fn().mockReturnValue(''),
+      handleSubmit: jest.fn((callback) => () => callback({ text: 'test message' })),
+    });
+    (useSearchParams as jest.Mock).mockReturnValue([
+      new URLSearchParams({ promptCatalogId: '123' }),
+      mockSetSearchParams,
+    ]);
+    (useQueryClient as jest.Mock).mockReturnValue({
+      getQueryData: mockGetQueryData,
+    });
+    (global.fetch as unknown as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ content: 'Prompt from catalog' }),
+    });
+
+    renderHook(() => useQueryParams({ textAreaRef: mockTextAreaRef }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+
+    expect(mockGetQueryData).toHaveBeenCalledWith(startupConfigKey(true));
+    expect(global.fetch).toHaveBeenCalledWith('/api/prompthub/resolve-insert', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+      },
+      body: JSON.stringify({ promptCatalogId: '123' }),
+    });
+    expect(mockSetValue).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+
+    expect(mockSetValue).toHaveBeenCalledWith(
+      'text',
+      'Prompt from catalog',
+      expect.objectContaining({ shouldValidate: true }),
+    );
+    expect(mockSetSearchParams).toHaveBeenCalledWith(
+      expect.any(URLSearchParams),
+      expect.objectContaining({ replace: true }),
+    );
+  });
+
+  it('should show a toast when resolving a Prompt Catalog insert fails', async () => {
+    const showToast = jest.fn();
+    const mockSetSearchParams = jest.fn();
+    const mockTextAreaRef = {
+      current: {
+        focus: jest.fn(),
+        setSelectionRange: jest.fn(),
+      } as unknown as HTMLTextAreaElement,
+    };
+
+    (useToastContext as jest.Mock).mockReturnValue({ showToast });
+    (useSearchParams as jest.Mock).mockReturnValue([
+      new URLSearchParams({ promptCatalogId: '123' }),
+      mockSetSearchParams,
+    ]);
+    (global.fetch as unknown as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: jest.fn().mockResolvedValue({ message: 'Prompt not found' }),
+    });
+
+    renderHook(() => useQueryParams({ textAreaRef: mockTextAreaRef }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.any(String),
+        severity: 'error',
+      }),
+    );
+    expect(mockSetSearchParams).toHaveBeenCalledWith(
+      expect.any(URLSearchParams),
+      expect.objectContaining({ replace: true }),
+    );
   });
 
   it('should defer submission when settings need to be applied first', () => {

--- a/client/src/hooks/Input/useQueryParams.ts
+++ b/client/src/hooks/Input/useQueryParams.ts
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useRef } from 'react';
-import { useToastContext } from '@librechat/client';
 import { useRecoilValue } from 'recoil';
 import { useSearchParams } from 'react-router-dom';
+import { useToastContext } from '@librechat/client';
 import { QueryClient, useQueryClient } from '@tanstack/react-query';
 import { QueryKeys, EModelEndpoint, PermissionBits } from 'librechat-data-provider';
 import type {
@@ -26,9 +26,9 @@ import {
   useSubmitMessage,
   useLocalize,
 } from '~/hooks';
+import { startupConfigKey, useGetAgentByIdQuery } from '~/data-provider';
 import { useChatContext, useChatFormContext } from '~/Providers';
 import { NotificationSeverity } from '~/common';
-import { useGetAgentByIdQuery } from '~/data-provider';
 import store from '~/store';
 
 const PROMPT_CATALOG_ID_QUERY_PARAM = 'promptCatalogId';
@@ -57,12 +57,12 @@ async function resolvePromptCatalogInsert(promptCatalogId: string, token: string
     throw new Error(data?.message || 'Failed to resolve Prompt Catalog insert');
   }
 
-  const promptText =
-    typeof data?.content === 'string'
-      ? data.content
-      : typeof data?.prompt === 'string'
-        ? data.prompt
-        : null;
+  let promptText: string | null = null;
+  if (typeof data?.content === 'string') {
+    promptText = data.content;
+  } else if (typeof data?.prompt === 'string') {
+    promptText = data.prompt;
+  }
 
   if (promptText == null) {
     throw new Error('PromptHub resolve response did not include prompt text');
@@ -118,7 +118,7 @@ export default function useQueryParams({
   const modularChat = useRecoilValue(store.modularChat);
   const availableTools = useRecoilValue(store.availableTools);
   const { submitMessage } = useSubmitMessage();
-  const { token, isAuthenticated } = useAuthContext();
+  const { user, token, isAuthenticated } = useAuthContext();
   const { showToast } = useToastContext();
   const localize = useLocalize();
 
@@ -149,7 +149,7 @@ export default function useQueryParams({
       }
       let newPreset: TPreset = removeUnavailableTools(_newPreset, availableTools);
       if (newPreset.spec != null && newPreset.spec !== '') {
-        const startupConfig = queryClient.getQueryData<TStartupConfig>([QueryKeys.startupConfig]);
+        const startupConfig = queryClient.getQueryData<TStartupConfig>(startupConfigKey(!!user));
         const modelSpecs = startupConfig?.modelSpecs?.list ?? [];
         const spec = modelSpecs.find((s) => s.name === newPreset.spec);
         if (!spec) {
@@ -238,6 +238,7 @@ export default function useQueryParams({
     },
     [
       queryClient,
+      user,
       modularChat,
       conversation,
       availableTools,
@@ -352,7 +353,7 @@ export default function useQueryParams({
       if (!textAreaRef.current) {
         return;
       }
-      const startupConfig = queryClient.getQueryData<TStartupConfig>([QueryKeys.startupConfig]);
+      const startupConfig = queryClient.getQueryData<TStartupConfig>(startupConfigKey(!!user));
       if (!startupConfig) {
         return;
       }
@@ -466,6 +467,7 @@ export default function useQueryParams({
     setSearchParams,
     getPreservedSearchParams,
     queryClient,
+    user,
     processSubmission,
     areSettingsApplied,
     isAuthenticated,


### PR DESCRIPTION
## Summary
- Fix Prompt Catalog deep-link handling after the LibreChat 0.8.7 startup config cache-key change
- Use the authenticated startup config query key before resolving `promptCatalogId`
- Restore regression coverage for successful Prompt Catalog insertion and failure toast behavior

## Validation
- `cd client && npx jest src/hooks/Input/useQueryParams.spec.ts --runInBand --coverage=false`
- `npx eslint client/src/hooks/Input/useQueryParams.ts client/src/hooks/Input/useQueryParams.spec.ts`