### PR TITLE
Register Prompt Catalog migration workflow

### DIFF
--- a/.github/workflows/migrate-prompts-to-catalog.yml
+++ b/.github/workflows/migrate-prompts-to-catalog.yml
@@ -1,0 +1,103 @@
+name: Migrate Prompts to Catalog
+
+# One-time (re-runnable/idempotent) migration of private LibreChat prompts into
+# the Paychex Prompt Catalog. Manual trigger only — see
+# config/migrate-prompts-to-catalog.js for the migration logic and
+# C:\git_source_control\reference_files\prompt-catalog-migration.md for the
+# full trigger/verification/cleanup runbook.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to migrate (each has its own Mongo database)'
+        required: true
+        type: choice
+        options:
+          - n1
+          - n2a
+          - prod
+      dry_run:
+        description: 'Dry run only (no writes to the Prompt Catalog)'
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  migrate:
+    name: "Migrate Prompts to Catalog: ${{ inputs.environment }}"
+    runs-on: ${{ inputs.environment == 'prod' && 'paychex-ai-platform-arc-prod' || 'paychex-ai-platform-arc-nonprod' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Resolve per-environment configuration
+        id: envconfig
+        run: |
+          case "${{ inputs.environment }}" in
+            n1|n2a)
+              echo "catalog_url=https://app-promptcatalog-api-eastus-nonprod-001.azurewebsites.net" >> "$GITHUB_OUTPUT"
+              ;;
+            prod)
+              echo "catalog_url=https://app-promptcatalog-api-eastus-prod-001.azurewebsites.net" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unknown environment: ${{ inputs.environment }}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Install dependencies
+        run: bash scripts/ci-npm-install.sh
+
+      - name: Build required packages
+        run: |
+          npm run build:data-provider
+          npm run build:data-schemas
+          npm run build:api
+
+      # Reads the per-environment Mongo connection string from a static
+      # GitHub repository secret (MONGO_URI_N1 / MONGO_URI_N2A / MONGO_URI_PROD)
+      # rather than fetching it live from Key Vault — no Azure login or Key
+      # Vault IAM grant required for the ARC runner service principal.
+      - name: Select Mongo URI secret for this environment
+        id: mongo
+        env:
+          MONGO_URI_N1: ${{ secrets.MONGO_URI_N1 }}
+          MONGO_URI_N2A: ${{ secrets.MONGO_URI_N2A }}
+          MONGO_URI_PROD: ${{ secrets.MONGO_URI_PROD }}
+        run: |
+          case "${{ inputs.environment }}" in
+            n1) VALUE="$MONGO_URI_N1" ;;
+            n2a) VALUE="$MONGO_URI_N2A" ;;
+            prod) VALUE="$MONGO_URI_PROD" ;;
+          esac
+          if [ -z "$VALUE" ]; then
+            echo "No MONGO_URI secret configured for environment '${{ inputs.environment }}'" >&2
+            exit 1
+          fi
+          echo "::add-mask::$VALUE"
+          echo "mongo_uri=$VALUE" >> "$GITHUB_OUTPUT"
+
+      - name: Run migration
+        env:
+          MONGO_URI: ${{ steps.mongo.outputs.mongo_uri }}
+          PROMPT_CATALOG_API_URL: ${{ steps.envconfig.outputs.catalog_url }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            npm run migrate:prompts-to-catalog:dry-run
+          else
+            npm run migrate:prompts-to-catalog:batch
+          fi
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "### Prompt Catalog Migration — ${{ inputs.environment }} (dry_run=${{ inputs.dry_run }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "See the step output above for the full migration/dry-run breakdown." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds .github/workflows/migrate-prompts-to-catalog.yml (workflow_dispatch) to develop so it is registered as a dispatchable Actions workflow.

Notes:
- This PR only registers the workflow definition on develop.
- The actual migration script (config/migrate-prompts-to-catalog.js) and its npm scripts already exist on feature/add-filters-to-ingrated-branch-merged-develop and will be used at run time when that branch/ref is selected in Run workflow, since workflow_dispatch executes using the workflow file and checked-out code from the selected ref.
- No functional migration logic is included in this PR, only the trigger definition.
- Once merged, N1 dry run can be triggered by selecting environment=n1, dry_run=true, and ref=feature/add-filters-to-ingrated-branch-merged-develop.