### PR TITLE
feat(models): add Claude Sonnet 5, remove Claude Sonnet 4.5 (n1/n2a/prod)

### DIFF
--- a/librechat.n1.yml
+++ b/librechat.n1.yml
@@ -13,7 +13,7 @@ modelSpecs:
     - azureOpenAI
     - "Gemini 2.5 Pro"
     - "Gemini 2.5 Flash"
-    - "Claude Sonnet 4.5"
+    - "Claude Sonnet 5"
   list:
     - name: azure-gpt-5.4-mini
       label: GPT-5.4 Mini
@@ -61,15 +61,15 @@ modelSpecs:
       preset:
         endpoint: "Gemini 2.5 Flash"
         model: gemini-2.5-flash
-    - name: anthropic-claude-sonnet-45
-      label: Claude Sonnet 4.5 (Limited)
+    - name: anthropic-claude-sonnet-5
+      label: Claude Sonnet 5 (Limited)
       iconURL: /assets/anthropic.png
       showIconInMenu: true
       showIconInHeader: true
       description: For extended reasoning, coding, and automation. This model is being evaluated. It can be used a limited number of times.
       preset:
-        endpoint: "Claude Sonnet 4.5"
-        model: claude-sonnet-4-5
+        endpoint: "Claude Sonnet 5"
+        model: claude-sonnet-5
 mcpServers:
   Internet Search (Tavily):
     type: streamable-http
@@ -141,17 +141,19 @@ endpoints:
       dropParams:
         - stream
         - streaming
-    - name: "Claude Sonnet 4.5"
+    - name: "Claude Sonnet 5"
       apiKey: "${GCP_VERTEXAI_API_KEY}"
-      baseURL: "${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1"
+      baseURL: "${GCP_VERTEXAI_BASEURL}/claude-sonnet-5/v1"
       iconURL: "/assets/anthropic.png"
       directEndpoint: true
       models:
         default:
-          - claude-sonnet-4-5
-      titleModel: "claude-sonnet-4-5"
+          - claude-sonnet-5
+      titleModel: "claude-sonnet-5"
       titleConvo: true
-      modelDisplayLabel: "Claude Sonnet 4.5"
+      modelDisplayLabel: "Claude Sonnet 5"
+      addParams:
+        max_tokens: 64000
       # Streaming enabled - Kong translates to OpenAI SSE format
       streamRate: 25
     - name: "LangGraph Agents"

--- a/librechat.n2a.yml
+++ b/librechat.n2a.yml
@@ -16,7 +16,7 @@ modelSpecs:
     - "Gemini 3.1 Flash Lite Preview"
     - "Gemini 3.1 Pro Preview"
     - "Gemini 3.1 Flash Image Preview"
-    - "Claude Sonnet 4.5"
+    - "Claude Sonnet 5"
     - "Claude Opus 4.6"
   list:
     - name: azure-gpt-5.4-mini
@@ -92,15 +92,15 @@ modelSpecs:
       preset:
         endpoint: "Gemini 3.1 Flash Image Preview"
         model: gemini-3.1-flash-image-preview
-    - name: anthropic-claude-sonnet-45
-      label: Claude Sonnet 4.5 (Limited)
+    - name: anthropic-claude-sonnet-5
+      label: Claude Sonnet 5 (Limited)
       iconURL: /assets/anthropic.png
       showIconInMenu: true
       showIconInHeader: true
       description: For extended reasoning, coding, and automation. This model is being evaluated. It can be used a limited number of times.
       preset:
-        endpoint: "Claude Sonnet 4.5"
-        model: claude-sonnet-4-5
+        endpoint: "Claude Sonnet 5"
+        model: claude-sonnet-5
     - name: anthropic-claude-opus-46
       label: Claude Opus 4.6 (Limited)
       iconURL: /assets/anthropic.png
@@ -232,17 +232,19 @@ endpoints:
       dropParams:
         - stream
         - streaming
-    - name: "Claude Sonnet 4.5"
+    - name: "Claude Sonnet 5"
       apiKey: "${GCP_VERTEXAI_API_KEY}"
-      baseURL: "${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1"
+      baseURL: "${GCP_VERTEXAI_BASEURL}/claude-sonnet-5/v1"
       iconURL: "/assets/anthropic.png"
       directEndpoint: true
       models:
         default:
-          - claude-sonnet-4-5
-      titleModel: "claude-sonnet-4-5"
+          - claude-sonnet-5
+      titleModel: "claude-sonnet-5"
       titleConvo: true
-      modelDisplayLabel: "Claude Sonnet 4.5"
+      modelDisplayLabel: "Claude Sonnet 5"
+      addParams:
+        max_tokens: 64000
       # Streaming enabled - Kong translates to OpenAI SSE format
       streamRate: 25
     - name: "Claude Opus 4.6"

--- a/librechat.prod.yml
+++ b/librechat.prod.yml
@@ -12,7 +12,7 @@ modelSpecs:
     - azureOpenAI
     - "Gemini 2.5 Pro"
     - "Gemini 2.5 Flash"
-    - "Claude Sonnet 4.5"
+    - "Claude Sonnet 5"
   list:
     - name: azure-gpt-5.4-mini
       label: GPT-5.4 Mini
@@ -60,15 +60,15 @@ modelSpecs:
       preset:
         endpoint: "Gemini 2.5 Flash"
         model: gemini-2.5-flash
-    - name: anthropic-claude-sonnet-45
-      label: Claude Sonnet 4.5 (Limited)
+    - name: anthropic-claude-sonnet-5
+      label: Claude Sonnet 5 (Limited)
       iconURL: /assets/anthropic.png
       showIconInMenu: true
       showIconInHeader: true
       description: For extended reasoning, coding, and automation. This model is being evaluated. It can be used a limited number of times.
       preset:
-        endpoint: "Claude Sonnet 4.5"
-        model: claude-sonnet-4-5
+        endpoint: "Claude Sonnet 5"
+        model: claude-sonnet-5
 mcpServers:
   Internet Search (Tavily):
     type: streamable-http
@@ -140,17 +140,19 @@ endpoints:
       dropParams:
         - stream
         - streaming
-    - name: "Claude Sonnet 4.5"
+    - name: "Claude Sonnet 5"
       apiKey: "${GCP_VERTEXAI_API_KEY}"
-      baseURL: "${GCP_VERTEXAI_BASEURL}/claude-sonnet-4-5/v1"
+      baseURL: "${GCP_VERTEXAI_BASEURL}/claude-sonnet-5/v1"
       iconURL: "/assets/anthropic.png"
       directEndpoint: true
       models:
         default:
-          - claude-sonnet-4-5
-      titleModel: "claude-sonnet-4-5"
+          - claude-sonnet-5
+      titleModel: "claude-sonnet-5"
       titleConvo: true
-      modelDisplayLabel: "Claude Sonnet 4.5"
+      modelDisplayLabel: "Claude Sonnet 5"
+      addParams:
+        max_tokens: 64000
       # Streaming enabled - Kong translates to OpenAI SSE format
       streamRate: 25
     - name: "LangGraph Agents"


### PR DESCRIPTION
## Summary

Adds **Claude Sonnet 5** and removes **Claude Sonnet 4.5** (the only older Sonnet present) from all three environment configs: `librechat.n1.yml`, `librechat.n2a.yml`, `librechat.prod.yml`.

## Model attributes

| Attribute | Value |
|---|---|
| `model_name` | `claude-sonnet-5` |
| `max_tokens` | `64000` |
| `model_vendor` | `anthropic` |
| `model_type` | `llm` |
| `model_provider` | `gcp` |

## Changes per env config

**Custom endpoint** (replaces the `Claude Sonnet 4.5` endpoint):
```yaml
- name: "Claude Sonnet 5"
  apiKey: "${GCP_VERTEXAI_API_KEY}"
  baseURL: "${GCP_VERTEXAI_BASEURL}/claude-sonnet-5/v1"
  iconURL: "/assets/anthropic.png"
  directEndpoint: true
  models:
    default:
      - claude-sonnet-5
  titleModel: "claude-sonnet-5"
  titleConvo: true
  modelDisplayLabel: "Claude Sonnet 5"
  addParams:
    max_tokens: 64000
  # Streaming enabled - Kong translates to OpenAI SSE format
  streamRate: 25
```

**modelSpec** — `anthropic-claude-sonnet-45` → `anthropic-claude-sonnet-5`, label `Claude Sonnet 5 (Limited)`, preset points at the new endpoint/model.

**addedEndpoints** — `"Claude Sonnet 4.5"` → `"Claude Sonnet 5"`.

## Implementation notes

- `model_vendor: anthropic` / `model_provider: gcp` are expressed the same way Sonnet 4.5 was: the Anthropic model served through the GCP Vertex AI path on `${GCP_VERTEXAI_BASEURL}` (Kong translates to OpenAI SSE format), with `iconURL: /assets/anthropic.png`.
- `max_tokens: 64000` is applied via endpoint-level `addParams` so the cap is enforced on every request, including when the endpoint is selected directly rather than through the model spec. (`maxOutputTokens` is not a valid custom-endpoint field in LibreChat's config schema.)
- The `(Limited)` label and evaluation wording were carried over from Sonnet 4.5, since Sonnet 5 replaces it under the same evaluation/quota arrangement. Easy to drop if that's no longer accurate.

## Not changed

- **Claude Opus 4.6** (n2a only) is untouched — it is not a Sonnet.
- No other endpoints, MCP servers, or interface settings modified.

## Verification

All three configs parsed with `js-yaml` and validated against LibreChat's `configSchema` from `@librechat/data-provider`:

```
librechat.n1.yml   VALID
librechat.n2a.yml  VALID
librechat.prod.yml VALID
```

Also confirmed for each file:
- no remaining `claude-sonnet-4-5` / `Claude Sonnet 4.5` references anywhere in the repo (outside upstream locale files, which are unrelated)
- every `modelSpecs.list[].preset.endpoint` resolves to a defined endpoint
- every `modelSpecs.addedEndpoints` entry resolves to a defined endpoint
