### PR TITLE
fix(ci): disable e2e video recording so Playwright retries actually run

### DIFF
--- a/e2e/playwright.config.ci.ts
+++ b/e2e/playwright.config.ci.ts
@@ -48,7 +48,9 @@ export default defineConfig({
     ignoreHTTPSErrors: true,
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
-    video: 'on-first-retry',
+    /** See e2e/playwright.config.mock.ts — CI has no ffmpeg, so video recording
+     * crashes the first retry instead of recording it. Traces cover debugging. */
+    video: 'off',
     storageState: path.resolve(__dirname, 'storageState.ci.json'),
   },
   expect: {

--- a/e2e/playwright.config.mock.ts
+++ b/e2e/playwright.config.mock.ts
@@ -121,7 +121,18 @@ export default defineConfig({
     : [['html', { outputFolder: reportPath }], ['list']],
   use: {
     baseURL,
-    video: 'on-first-retry',
+    /**
+     * Video recording requires Playwright's bundled ffmpeg binary, which CI does
+     * not install: the workflow sets `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` and runs
+     * `playwright install-deps chrome` (OS libraries for the system Chrome channel
+     * only). With `on-first-retry`, every retry #1 aborted with "Executable doesn't
+     * exist ... ffmpeg-linux" before running a single assertion, silently reducing
+     * the retry budget from 2 to 1 and turning flaky specs into hard failures.
+     * `trace: 'retain-on-failure'` below already captures DOM snapshots, network
+     * activity, and per-action screenshots, which is strictly more useful for
+     * debugging than a video.
+     */
+    video: 'off',
     trace: 'retain-on-failure',
     ignoreHTTPSErrors: true,
     headless: true,


### PR DESCRIPTION
## Problem

Both CI Playwright profiles record video on the first retry:

```ts
// e2e/playwright.config.mock.ts and e2e/playwright.config.ci.ts
video: 'on-first-retry',
```

Video recording requires Playwright's bundled **ffmpeg** binary — which CI never installs:

- **`playwright-mock.yml`** sets `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'` and runs only `npx playwright install-deps chrome`. `install-deps` installs *OS libraries* for the system Chrome channel, never Playwright binaries.
- **`e2e-tests.yml`** runs `npx playwright install --with-deps chromium`. `ffmpeg` has `installByDefault: true`, so a bare `playwright install` would fetch it — but naming a browser explicitly installs *only* that browser.

So **every retry #1 aborts before running a single assertion:**

```
Error: browserContext.newPage: Executable doesn't exist at
/home/runner/.cache/ms-playwright/ffmpeg-1011/ffmpeg-linux
```

The configs set `retries: 2`, but retry #1 is always burned on this crash — the effective budget is **1**, which is enough to tip borderline-flaky specs into hard job failures.

## Evidence

In [run 30579762267](https://github.com/paychex/LibreChat/actions/runs/30579762267) this fired **4 times**, once per test that reached a retry. Final tally `2 failed, 2 flaky, 71 passed`; the two hard failures were ordinary timing flake (`isolation.spec.ts:64` login `waitForURL` timeout, `sidebar.spec.ts:44` "Execution context was destroyed"). Re-running that job with no code changes came back **green**, confirming a working retry would have absorbed them.

The same job also fails on unrelated PRs with a *different* set of specs, confirming infrastructure flake rather than any single change.

## Why not just install ffmpeg?

That was the first attempt and it was rejected empirically. In [run 30581144044](https://github.com/paychex/LibreChat/actions/runs/30581144044) the download succeeds, then `npx playwright install ffmpeg` **hangs** — it runs after `install-deps` has switched to root, and never returns:

```
20:55:40  (install-deps finishes)
20:55:42  Downloading FFMPEG playwright build v1011 ...
          |████████████| 100% of 2.3 MiB
21:00:37  ##[error]The action 'Install Playwright runtime dependencies' has timed out after 5 minutes.
```

That trades one CI failure for another. Dropping the dependency is deterministic.

## Fix

Set `video: 'off'` in both CI profiles.

- `trace: 'retain-on-failure'` and `screenshot: 'only-on-failure'` are **unchanged** — traces already capture DOM snapshots, network activity, and per-action screenshots, which is strictly more useful for debugging than a video.
- `e2e/playwright.config.real.ts` already used `video: 'off'`, so all profiles are now consistent.

## Verification

- `npx tsc --noEmit` clean on the changed configs; lint-staged (prettier + eslint) passed on commit.
- Confirmed locally that `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npx playwright install ffmpeg` pulls exactly the `ffmpeg-1011` path CI reported missing — i.e. the diagnosis is right; this PR removes the need for it.
- This PR's own `Playwright E2E Tests` run exercises the change directly.

## Scope

CI/test configuration only. No application code and no Paychex customizations touched. This does not make the flaky specs deterministic — it restores the retry budget that was being silently thrown away.
